### PR TITLE
fix: add viewport-fit=cover and remove legacy status bar meta tag for…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taqwa-tracker",
-      "version": "3.0.8",
+      "version": "3.0.9",
       "dependencies": {
         "@angular/animations": "^21.1.0",
         "@angular/common": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>The Taqwa Tracker - Complete Islamic Companion App</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="icons/icon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="icons/icon-72x72.png">


### PR DESCRIPTION
… iOS PWA theme sync

This commit ensures correct status bar theming on iOS PWAs by:
1. Adding `viewport-fit=cover` to the `viewport` meta tag. This is required for the `theme-color` meta tag to affect the status bar area on notch devices.
2. Ensuring `<meta name="apple-mobile-web-app-status-bar-style" content="default">` is removed (confirmed in index.html). This legacy tag forces a white/default status bar, overriding dynamic `theme-color` updates.

Also bumped version to 3.0.9.