### PR TITLE
fix: set status bar to black-translucent and bump version to 3.0.9

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -23,6 +23,7 @@
   <meta name="theme-color" content="#1e293b">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="description"
     content="Complete Islamic Companion App - The Taqwa Tracker provides prayer times, Qibla direction, Quran reader, Hadith search, Islamic calendar, Tasbih counter, reading streaks, AI chatbot & Islamic library. Your all-in-one Muslim lifestyle app.">
   <meta name="keywords"


### PR DESCRIPTION
This commit sets the `apple-mobile-web-app-status-bar-style` meta tag to `black-translucent` and adds `viewport-fit=cover` to the `viewport` meta tag. This configuration forces the status bar to be transparent and float over the app content, allowing the app's background color (and theme) to be visible behind the status bar text on iOS PWAs. This addresses the issue where the status bar remained white in dark mode.

Also bumped version to 3.0.9.