### PR TITLE
fix: add global body background style for iOS PWA status bar sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taqwa-tracker",
-      "version": "3.0.9",
+      "version": "3.0.10",
       "dependencies": {
         "@angular/animations": "^21.1.0",
         "@angular/common": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,10 @@
   /* This helps with font loading behavior */
 }
 
+html, body {
+  @apply bg-gray-200 dark:bg-slate-700 min-h-screen;
+}
+
 .app-bg {
   @apply bg-white dark:bg-slate-800 w-full md:max-w-2xl min-h-screen text-center text-slate-900 dark:text-gray-300 rounded-none md:rounded-lg shadow-lg;
 }


### PR DESCRIPTION
This commit adds a global `html, body` style to `src/styles.css` that sets the background color to match the app's theme (`bg-gray-200` / `dark:bg-slate-700`). This is necessary because the iOS PWA status bar is set to `black-translucent` (transparent), which reveals the root element's background color. Previously, the default white body background was visible through the status bar, preventing it from appearing dark in Dark Mode.

Also bumped version to 3.0.10.