### PR TITLE
Sync compass needle sizes

### DIFF
--- a/src/app/home/tool/kaaba/kaaba.component.css
+++ b/src/app/home/tool/kaaba/kaaba.component.css
@@ -1,0 +1,3 @@
+.compass-layer {
+    @apply absolute inset-4 w-[calc(100%-2rem)] h-[calc(100%-2rem)];
+}

--- a/src/app/home/tool/kaaba/kaaba.component.html
+++ b/src/app/home/tool/kaaba/kaaba.component.html
@@ -48,7 +48,7 @@
         </div>
 
         <!-- Rotating Compass (SAME SIZE AS NEEDLE) -->
-        <div class="absolute inset-4 w-[calc(100%-2rem)] h-[calc(100%-2rem)]"
+        <div class="compass-layer"
             [style.transform]="'rotate(' + compassDeg() + 'deg)'">
             <!-- Compass Background -->
             <div
@@ -77,7 +77,7 @@
 
         <!-- Fixed Compass Needle - MUST MATCH ROTATING COMPASS SIZE -->
         <div
-            class="absolute inset-4 w-[calc(100%-2rem)] h-[calc(100%-2rem)] flex items-center justify-center pointer-events-none">
+            class="compass-layer flex items-center justify-center pointer-events-none">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" class="w-full h-full"
                 aria-label="Compass needle">
                 <!-- Needle Shadow -->


### PR DESCRIPTION
Extracted shared Tailwind classes for the rotating compass container and the fixed needle container into a reusable `.compass-layer` CSS class in `kaaba.component.css`. This ensures that both elements maintain the same size and positioning, preventing visual discrepancies.

---
*PR created automatically by Jules for task [15906639592050987214](https://jules.google.com/task/15906639592050987214) started by @ezazulhaq*