### PR TITLE
fix: resolve concurrent token refresh & invalid payload (v3.2.1)

### DIFF
--- a/src/app/service/auth.service.ts
+++ b/src/app/service/auth.service.ts
@@ -268,7 +268,9 @@ export class AuthService {
       return this.refreshObservable;
     }
 
-    this.refreshObservable = this.http.post<LoginResponse>(`${this.API_BASE_URL}/auth/refresh`, { refresh_token: refreshToken }).pipe(
+    const params = new HttpParams().set('refresh_token', refreshToken);
+
+    this.refreshObservable = this.http.post<LoginResponse>(`${this.API_BASE_URL}/auth/refresh`, null, { params }).pipe(
       map(tokenResponse => {
         // Store new tokens with expiration
         this.authTokenService.setTokens(


### PR DESCRIPTION
- Updated `AuthService.refreshSession` to send the `refresh_token` as a query parameter (using `HttpParams`) instead of a JSON body, fixing a 422 Unprocessable Entity error.
- Implemented `shareReplay(1)` in `AuthService` to handle concurrent refresh requests, preventing race conditions.
- Refactored `AuthInterceptor` to queue requests during refresh.
- Updated RxJS imports and bumped version to 3.2.1.