### PR TITLE
feat: Track last read page in Library streaks & gate behind auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taqwa-tracker",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "dependencies": {
         "@angular/animations": "^21.1.0",
         "@angular/common": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/home/sacred/library/reader/reader.component.html
+++ b/src/app/home/sacred/library/reader/reader.component.html
@@ -1,1 +1,2 @@
-<app-pdf-viewer [pdfSrc]="pdfSrc" [storageKey]="storageKey"></app-pdf-viewer>
+<app-pdf-viewer [pdfSrc]="pdfSrc" [storageKey]="storageKey" [initialPage]="initialPage()"
+    (pageChange)="onPageChange($event)"></app-pdf-viewer>

--- a/src/app/home/sacred/library/reader/reader.component.ts
+++ b/src/app/home/sacred/library/reader/reader.component.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { environment } from '../../../../../environments/environment';
 import { PdfViewerComponent } from '../../../../shared/pdf-viewer/pdf-viewer.component';
 import { ReadStreakService } from '../../../../service/read-streak.service';
+import { AuthTokenService } from '../../../../service/auth-token.service';
 import { ReadItem } from '../../../streak-dashboard/streak-dashboard.model';
 
 @Component({
@@ -15,31 +16,56 @@ import { ReadItem } from '../../../streak-dashboard/streak-dashboard.model';
     class: 'app-bg'
   }
 })
-export class ReaderComponent {
+export class ReaderComponent implements OnDestroy {
 
   pdfSrc!: string;
   storageKey!: string;
+  initialPage = signal<number | undefined>(undefined);
 
   private pdfName = '';
   private category = '';
+  private currentPage = 1;
+  private hasTrackedInitial = false;
 
   private readonly route = inject(ActivatedRoute);
   private readonly readStreakService = inject(ReadStreakService);
+  private readonly authTokenService = inject(AuthTokenService);
 
   ngOnInit() {
     this.route.queryParams.subscribe(params => {
       this.pdfName = params['pdfName'] ?? '';
       this.category = params['category'] ?? '';
       this.storageKey = params['storageKey'] ?? '';
+      const pageParam = params['page'];
+      if (pageParam) {
+        this.initialPage.set(+pageParam);
+        this.currentPage = +pageParam;
+      }
       this.pdfSrc = `https://${environment.github.pdfUri}/${this.category}/${this.pdfName}`;
-      this.trackReading();
+
+      // Track initial read (count=1) only once
+      if (!this.hasTrackedInitial) {
+        this.trackReading(1);
+        this.hasTrackedInitial = true;
+      }
     });
   }
 
-  private trackReading(): void {
-    if (!this.pdfName) return;
+  ngOnDestroy() {
+    // Update streak link with latest page (count=0 to avoid double counting)
+    if (this.authTokenService.isAuthenticated()) {
+      this.trackReading(0);
+    }
+  }
 
-    const link = `/reader?pdfName=${encodeURIComponent(this.pdfName)}&category=${encodeURIComponent(this.category)}&storageKey=${encodeURIComponent(this.storageKey)}`;
+  onPageChange(page: number): void {
+    this.currentPage = page;
+  }
+
+  private trackReading(count: number): void {
+    if (!this.pdfName || !this.authTokenService.isAuthenticated()) return;
+
+    const link = `/reader?pdfName=${encodeURIComponent(this.pdfName)}&category=${encodeURIComponent(this.category)}&storageKey=${encodeURIComponent(this.storageKey)}&page=${this.currentPage}`;
 
     const readItem: ReadItem = {
       type: 'library',
@@ -49,7 +75,7 @@ export class ReaderComponent {
       timestamp: new Date().toISOString()
     };
 
-    this.readStreakService.trackRead(1, readItem);
+    this.readStreakService.trackRead(count, readItem);
   }
 
   private formatTitle(value: string): string {

--- a/src/app/shared/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/shared/pdf-viewer/pdf-viewer.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { Component, Inject, OnInit, PLATFORM_ID, computed, effect, input, signal } from '@angular/core';
+import { Component, Inject, OnInit, PLATFORM_ID, computed, effect, input, output, signal } from '@angular/core';
 import { PDFProgressData, PDFDocumentProxy, PdfViewerModule } from 'ng2-pdf-viewer';
 import { FormsModule } from '@angular/forms';
 import { IslamicLibrary } from '../../model/islamic-library.model';
@@ -18,6 +18,9 @@ export class PdfViewerComponent implements OnInit {
 
   pdfSrc = input.required<string>();
   storageKey = input.required<string>();
+  initialPage = input<number>();
+
+  pageChange = output<number>();
 
   page = signal<number>(1);
   pagesRendered = signal<number>(0);
@@ -29,13 +32,20 @@ export class PdfViewerComponent implements OnInit {
   constructor(@Inject(PLATFORM_ID) private readonly platformId: Object) {
     effect(() => {
       this.updateIslamicLibrary();
-    })
+    });
+    effect(() => {
+      this.pageChange.emit(this.page());
+    });
   }
 
   ngOnInit() {
     if (isPlatformBrowser(this.platformId)) {
+      const overridePage = this.initialPage();
       const islamicLibrary = this.getIslamicLibraryFromLocalStorage()?.find(item => item.storageKey === this.storageKey()) ?? null;
-      if (islamicLibrary) {
+      if (overridePage && overridePage > 0) {
+        this.page.set(overridePage);
+        this.zoom.set(islamicLibrary?.zoom ?? 1);
+      } else if (islamicLibrary) {
         this.page.set(islamicLibrary.page ?? 1);
         this.zoom.set(islamicLibrary.zoom ?? 1);
       }


### PR DESCRIPTION
## Summary

This PR adds page-number tracking to Library PDF reading streaks and gates streak tracking behind authentication.

## Changes

### Page-Tracked Reading
- **`PdfViewerComponent`**: Added `pageChange` output (emits on every page navigation) and `initialPage` input (accepts page override from streak deep links)
- **`ReaderComponent`**: Tracks `currentPage` from `pageChange` events. On `ngOnDestroy`, updates the streak link with `&page=N` using `trackRead(0)` (count=0 to avoid duplicate counting)
- **"Continue Reading"** links now include the exact page number, navigating directly to the last-read page

### Auth-Gated Tracking
- Streak tracking only fires when `AuthTokenService.isAuthenticated()` returns `true`
- Unauthenticated users can still read PDFs freely — their activity just isn't tracked

### Deduplication Fix
- Subtitle kept as category only (no page number) so `updateRecentItems` correctly matches and replaces the existing entry instead of creating duplicates

## Files Changed

| File | Change |
|------|--------|
| `pdf-viewer.component.ts` | Added `pageChange` output, `initialPage` input, page emission effect |
| `reader.component.ts` | Auth gating, page tracking, `trackRead(0)` on destroy |
| `reader.component.html` | Bound `(pageChange)` and `[initialPage]` |

## Verification

- ✅ Tested manually: page tracking works, no duplicates, auth gating works