### PR TITLE
feat(journey): enrich prophet stories with detailed prose and interactive choices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taqwa-tracker",
-      "version": "3.3.6",
+      "version": "3.3.7",
       "dependencies": {
         "@angular/animations": "^21.1.0",
         "@angular/common": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/home/games/journey/data/muhammad.ts
+++ b/src/app/home/games/journey/data/muhammad.ts
@@ -4,341 +4,320 @@ export const MUHAMMAD_JOURNEY: Journey = {
     id: 'muhammad',
     prophetName: 'Muhammad (SAW)',
     title: 'Seal of the Prophets',
-    description: 'The Final Journey. Experience the Seerah from the Cave of Hira to the heights of Sidrat-ul-Muntaha, and the establishment of Islam.',
+    description: 'The Final Journey. Experience the Seerah from the Cave of Hira to the heights of Sidrat-ul-Muntaha, and the magnificent establishment of Islam across the earth.',
     icon: '🕌',
     themeColor: 'emerald',
     scenes: [
-        // PHASE 1: The Beginning of Revelation
+        // PRE-REVELATION
         {
             id: 'start',
-            title: 'The Cave of Hira',
-            text: 'It is the year 610 CE. Muhammad (SAW), aged 40, retreats to the Cave of Hira seeking solitude and truth. Suddenly, the Angel Jibril appears, filling the horizon.',
-            themeColor: 'slate',
-            imageHint: '⛰️',
-            choices: [
-                { text: 'Wait in stillness', nextSceneId: 'read', wisdomAdded: 1 }
-            ]
-        },
-        {
-            id: 'read',
-            title: 'The First Command',
-            text: 'Jibril commands: "Iqra!" (Read!). The Prophet replies, "I cannot read." The angel embraces him tightly three times, then reveals: "Read in the name of your Lord who created..."',
-            themeColor: 'emerald',
-            imageHint: '📖',
-            choices: [
-                { text: 'Rush home to Khadijah (RA)', nextSceneId: 'khadijah', wisdomAdded: 2 }
-            ]
-        },
-        {
-            id: 'khadijah',
-            title: 'The Comfort of Khadijah',
-            text: 'Trembling, he returns home: "Cover me! Cover me!" Khadijah (RA) comforts him: "Allah will never disgrace you. You unite relations, bear the burden of the weak, and help the poor."',
-            themeColor: 'rose',
-            imageHint: '🏠',
-            choices: [
-                { text: 'Visit Waraqah ibn Nawfal', nextSceneId: 'waraqah', wisdomAdded: 2 }
-            ]
-        },
-        {
-            id: 'waraqah',
-            title: 'The Prediction',
-            text: 'Waraqah, a wise Christian scholar, confirms: "This is the Namus (Angel) sent to Musa. I wish I could be alive when your people drive you out." The Prophet is shocked: "Will they drive me out?"',
-            themeColor: 'amber',
-            imageHint: '📜',
-            choices: [
-                { text: 'Accept the burden of Prophethood', nextSceneId: 'secret_call', wisdomAdded: 3 }
-            ]
-        },
-
-        // PHASE 2: The Secret and Open Call
-        {
-            id: 'secret_call',
-            title: 'The Secret Invitation',
-            text: 'For three years, the message involves only the closest family and friends. Abu Bakr, Ali, and Zayd (RA) occupy the first ranks of believers.',
-            themeColor: 'slate',
-            imageHint: '🤫',
-            choices: [
-                { text: 'Receive the command to preach openly', nextSceneId: 'safa', wisdomAdded: 2 }
-            ]
-        },
-        {
-            id: 'safa',
-            title: 'Mount Safa',
-            text: 'The Prophet ascends Mount Safa and calls the tribes. "If I told you an army was behind this mountain, would you believe me?" They say yes. "Then I warn you of a severe punishment."',
-            themeColor: 'orange',
-            imageHint: '⛰️',
-            choices: [
-                { text: 'Face the rejection of Abu Lahab', nextSceneId: 'persecution', wisdomAdded: 1 }
-            ]
-        },
-        {
-            id: 'persecution',
-            title: 'Era of Persecution',
-            text: 'The Quraish respond with mockery and torture. Bilal (RA) is dragged on burning sands. The Prophet (SAW) is strangled while praying. The believers hold firm.',
-            themeColor: 'red',
-            imageHint: '🔥',
-            choices: [
-                { text: 'Allow migration to Abyssinia', nextSceneId: 'abyssinia', wisdomAdded: 3 },
-                { text: 'Pray for the strength of Umar', nextSceneId: 'umar', wisdomAdded: 3 }
-            ]
-        },
-        {
-            id: 'abyssinia',
-            title: 'The Just King',
-            text: 'Ruler Negus of Abyssinia listens to Ja\'far (RA) recite Surah Maryam. He weeps and draws a line: "The difference between us and you is no more than this line."',
-            themeColor: 'blue',
-            imageHint: '👑',
-            choices: [
-                { text: 'Return focus to Mecca', nextSceneId: 'search_strength', wisdomAdded: 2 }
-            ]
-        },
-        {
-            id: 'umar',
-            title: 'The Farooq',
-            text: 'Umar ibn al-Khattab, intending to kill the Prophet, hears the Quran at his sister\'s house. His heart softens. He declares his Islam, and the Muslims can finally pray openly at the Kaaba.',
-            themeColor: 'emerald',
-            imageHint: '⚔️',
-            choices: [
-                { text: 'Strengthen the community', nextSceneId: 'search_strength', wisdomAdded: 4 }
-            ]
-        },
-        {
-            id: 'search_strength',
-            title: 'Boycott and Loss',
-            text: 'The Quraish boycott the Banu Hashim for three years. They eat leaves to survive. Soon after, Khadijah (RA) and Abu Talib pass away. It is the Year of Sorrow.',
-            themeColor: 'slate',
-            imageHint: '🍂',
-            choices: [
-                { text: 'Travel to Taif', nextSceneId: 'taif', wisdomAdded: 2 }
-            ]
-        },
-        {
-            id: 'taif',
-            title: 'The Trial of Taif',
-            text: 'Thinking Taif might accept him, he goes there. They stone him until his shoes fill with blood. The Angel of Mountains offers to crush them. The Prophet says: "No, perhaps Allah will raise from them those who worship Him alone."',
-            themeColor: 'rose',
-            imageHint: '🩸',
-            choices: [
-                { text: 'Show mercy and patience', nextSceneId: 'isra', wisdomAdded: 10 }
-            ]
-        },
-
-        // PHASE 3: Isra and Mi'raj
-        {
-            id: 'isra',
-            title: 'The Night Journey',
-            text: 'Jibril arrives with Buraq. In a single night, the Prophet travels to Jerusalem, leads all Prophets in prayer, and ascends to the Heavens.',
-            themeColor: 'indigo',
-            imageHint: '🌌',
-            choices: [
-                { text: 'Ascend to Sidrat-ul-Muntaha', nextSceneId: 'miraj', wisdomAdded: 5 }
-            ]
-        },
-        {
-            id: 'miraj',
-            title: 'The Gift of Salah',
-            text: 'Beyond where even Jibril could go, the Prophet receives the command of 50 prayers, reduced to 5 out of Allah\'s mercy, with the reward of 50.',
-            themeColor: 'primary',
-            imageHint: '🛐',
-            choices: [
-                { text: 'Return to Mecca', nextSceneId: 'pledge', wisdomAdded: 5 }
-            ]
-        },
-
-        // PHASE 4: Hijrah
-        {
-            id: 'pledge',
-            title: 'Pledge of Aqabah',
-            text: 'Pilgrims from Yathrib (Medina) meet him secretly. They pledge to protect him. The command for Hijrah (Migration) is given.',
-            themeColor: 'emerald',
-            imageHint: '🤝',
-            choices: [
-                { text: 'Leave Mecca with Abu Bakr', nextSceneId: 'cave_thawr', wisdomAdded: 3 }
-            ]
-        },
-        {
-            id: 'cave_thawr',
-            title: 'The Cave of Thawr',
-            text: 'Pursued by bounty hunters, they hide in a small cave. A spider spins a web; a bird lays eggs. Abu Bakr whispers fear, but the Prophet says: "Do not grieve; indeed Allah is with us."',
-            themeColor: 'slate',
-            imageHint: '🕸️',
-            choices: [
-                { text: 'Trust in Allah\'s Plan', nextSceneId: 'madinah_arrival', wisdomAdded: 5 }
-            ]
-        },
-        {
-            id: 'madinah_arrival',
-            title: 'Arrival in Madinah',
-            text: 'The people of Madinah rush out singing "Tala\'a al-Badru \'Alayna". The Prophet lets his camel, Qaswa, choose where to stay. The era of the State begins.',
-            themeColor: 'green',
-            imageHint: '🌴',
-            choices: [
-                { text: 'Build the Masjid', nextSceneId: 'brotherhood', wisdomAdded: 3 }
-            ]
-        },
-        {
-            id: 'brotherhood',
-            title: 'Bond of Brotherhood',
-            text: 'The Prophet pairs every Muhajir (Immigrant) with an Ansari (Helper). They share wealth and homes. A society based on faith, not tribe, is born.',
-            themeColor: 'emerald',
-            imageHint: '❤️',
-            choices: [
-                { text: 'Establish the Constitution', nextSceneId: 'badr', wisdomAdded: 3 }
-            ]
-        },
-
-        // PHASE 5: The Battles
-        {
-            id: 'badr',
-            title: 'The Day of Criterion',
-            text: '313 Muslims face 1000 well-armed Quraish at Badr. The Prophet prays until his cloak falls. Angels descend to assist. A decisive victory for Truth.',
-            themeColor: 'primary',
-            imageHint: '⚔️',
-            choices: [
-                { text: 'Show mercy to captives', nextSceneId: 'uhud', wisdomAdded: 4 }
-            ]
-        },
-        {
-            id: 'uhud',
-            title: 'The Lesson of Uhud',
-            text: 'Thinking the battle won, archers leave their posts. Khalid ibn Walid (not yet Muslim) flanks them. The Prophet is injured; Hamza (RA) is martyred. A test of obedience and resilience.',
-            themeColor: 'mustard', // Custom handling needed or fallback
-            imageHint: '🏹',
-            choices: [
-                { text: 'Regroup and endure', nextSceneId: 'trench', wisdomAdded: 3 }
-            ]
-        },
-        {
-            id: 'trench',
-            title: 'Battle of the Trench',
-            text: '10,000 confederates besiege Madinah. Salman al-Farsi suggests digging a trench. Cold and hunger bite, but the Prophet strikes a rock and sees the palaces of Persia and Rome falling to Islam.',
-            themeColor: 'slate',
-            imageHint: '🛡️',
-            choices: [
-                { text: 'Trust in the Victory', nextSceneId: 'hudaybiyyah', wisdomAdded: 4 }
-            ]
-        },
-
-        // PHASE 6: Victory and Peace
-        {
-            id: 'hudaybiyyah',
-            title: 'Treaty of Hudaybiyyah',
-            text: 'Intending Umrah, they are stopped. A treaty is signed that looks humiliating (returning Muslims). Umar (RA) is furious, but it is a "Manifest Victory" allowing Islam to spread peacefully.',
-            themeColor: 'white', // Light theme
-            imageHint: '📝',
-            choices: [
-                { text: 'Send letters to Kings', nextSceneId: 'letters', wisdomAdded: 5 }
-            ]
-        },
-        {
-            id: 'letters',
-            title: 'Letters to Empires',
-            text: 'The Prophet sends envoys to Heraclius (Rome), Chosroes (Persia), and others, inviting them to Islam. The message goes global.',
-            themeColor: 'indigo',
-            imageHint: '✉️',
-            choices: [
-                { text: 'Prepare for Mecca', nextSceneId: 'conquest', wisdomAdded: 3 }
-            ]
-        },
-        {
-            id: 'conquest',
-            title: 'Conquest of Mecca',
-            text: 'The Quraish break the treaty. 10,000 Muslims march on Mecca. Not a drop of blood is shed. The Prophet stands at the Kaaba door: "Go, for you are free!"',
-            themeColor: 'emerald',
-            imageHint: '🕋',
-            choices: [
-                { text: 'Smash the 360 idols', nextSceneId: 'hunayn', wisdomAdded: 10 }
-            ]
-        },
-        {
-            id: 'hunayn',
-            title: 'Valley of Hunayn',
-            text: 'Flush with victory, some Muslims rely on numbers (12,000). They are ambushed. The Prophet stands firm: "I am the Prophet, no lie! I am the son of Abdul Muttalib!" Order is restored.',
-            themeColor: 'orange',
-            imageHint: '🏜️',
-            choices: [
-                { text: 'Distribute charity', nextSceneId: 'tabuk', wisdomAdded: 3 }
-            ]
-        },
-        {
-            id: 'tabuk',
-            title: 'The Hardship',
-            text: 'A march to Tabuk in blistering heat to face Rome. The hypocrites stay behind. Results in treaties and the consolidation of Arabia.',
-            themeColor: 'amber',
-            imageHint: '☀️',
-            choices: [
-                { text: 'Year of Delegations', nextSceneId: 'farewell', wisdomAdded: 3 }
-            ]
-        },
-
-        // PHASE 7: The Farewell
-        {
-            id: 'farewell',
-            title: 'The Farewell Hajj',
-            text: '100,000 companions join him. On Mount Arafat, he delivers the final sermon: "No Arab has superiority over a non-Arab... Treat women well... I leave behind the Quran and my Sunnah."',
-            themeColor: 'primary',
-            imageHint: '⛰️',
-            choices: [
-                { text: 'Witness the perfection of Deen', nextSceneId: 'illness', wisdomAdded: 5 }
-            ]
-        },
-        {
-            id: 'illness',
-            title: 'The Choice',
-            text: 'The Prophet falls ill. He asks permission from his wives to stay with Aisha (RA). He tells the people: "Allah gave a servant a choice between this world and what is with Him. The servant chose what is with Him."',
-            themeColor: 'rose',
-            imageHint: '🛌',
-            choices: [
-                { text: 'Understand the farewell', nextSceneId: 'death', wisdomAdded: 2 }
-            ]
-        },
-        {
-            id: 'death',
-            title: 'The Companion on High',
-            text: 'Head on Aisha\'s lap, using the Miswak. His final words: "To the Highest Companion." The seal of Prophethood is closed. The revelation ends.',
-            themeColor: 'slate',
-            imageHint: '☝️',
-            choices: [
-                { text: 'Face the grief', nextSceneId: 'legacy', wisdomAdded: 0 }
-            ]
-        },
-        {
-            id: 'legacy',
-            title: 'The Everlasting Sample',
-            text: 'Abu Bakr (RA) declares: "Whoever worshipped Muhammad, know that Muhammad is dead. But whoever worships Allah, He is Ever-Living and does not die." The Message lives on.',
-            themeColor: 'emerald',
-            imageHint: '✨',
-            choices: [] // End of Journey
-        },
-
-        // --- EXPANSIONS FOR DEPTH (Adding details to hit 50+ scenes) ---
-        // Inserting these into logical flows via checks or side-stories 
-        // (Note: For brevity in this code view, I've outlined the main arc above (25 scenes).
-        // To strictly hit 50+, I would need to decompose events like "Battle of Badr" into 
-        // "Badr: The Wells", "Badr: The Duel", "Badr: The Dust", etc.
-        // Given text limits, I will add intermediate scenes now.)
-
-        {
-            id: 'hilf_al_fudul',
             title: 'The Pact of Virtues',
-            text: '(Flashback) Young Muhammad witnesses the leaders of Mecca swearing to protect the oppressed. He would later say: "I would not trade my presence there for red camels."',
+            text: 'Years before the monumental weight of Prophethood descended upon his shoulders, a young Muhammad fiercely witnessed the noble leaders of Mecca forge a magnificent, unbreakable pact to fiercely protect the oppressed (Hilf al-Fudul). He valued this noble commitment to raw justice above the most precious wealth of Arabia.',
             themeColor: 'indigo',
             imageHint: '🤝',
             choices: [
-                { text: 'Continue', nextSceneId: 'khadijah_marriage', wisdomAdded: 2 }
+                { text: 'Value justice higher than wealth.', nextSceneId: 'khadijah_marriage', wisdomAdded: 3 },
+                { text: 'Ignore it as a tribal affair.', nextSceneId: 'khadijah_marriage', wisdomAdded: 0, feedback: 'He always valued justice, saying he would join such a pact even in Islam.' }
             ]
         },
         {
             id: 'khadijah_marriage',
             title: 'Marriage to Khadijah',
-            text: 'Impressed by his honesty (Al-Amin), Khadijah proposes. A union of love and support that anchors his life.',
+            text: 'Widely acclaimed in Mecca as "Al-Amin" (The Trustworthy) for his flawless, stellar honesty in highly lucrative international trade, the incredibly noble and wealthy Khadijah (RA) boldly proposed marriage. It rapidly blossomed into an extraordinarily deeply blessed, passionate union defined by unwavering love and fierce, absolute support.',
             themeColor: 'rose',
             imageHint: '💍',
             choices: [
-                { text: 'Continue to Revelation', nextSceneId: 'start', wisdomAdded: 2 }
+                { text: 'Enter the marriage with integrity and love.', nextSceneId: 'hira', wisdomAdded: 3 }
             ]
         },
-        // ... (Adding ~20 more scenes would make this file huge, I will optimize for high quality main arc first, 
-        // then iterate if user specifically counts. The current arc covers the entire life comprehensively.)
+        // PHASE 1: The Beginning of Revelation
+        {
+            id: 'hira',
+            title: 'The Cave of Hira',
+            text: 'In the deeply quiet, still year of 610 CE, aged forty, he constantly retreated to the towering, dangerously narrow Cave of Hira, desperately seeking absolute truth to escape the brutally toxic, heavily idolatrous society of Mecca. Amidst his intense spiritual solitude, an overwhelmingly massive, terrifying presence suddenly materialized.',
+            themeColor: 'slate',
+            imageHint: '⛰️',
+            choices: [
+                { text: 'Run away immediately in utter terror.', nextSceneId: 'read', wisdomAdded: 0, feedback: 'Though terrified, he stayed, and the Angel embraced him.' },
+                { text: 'Wait in stillness, despite the immense weight.', nextSceneId: 'read', wisdomAdded: 4 }
+            ]
+        },
+        {
+            id: 'read',
+            title: 'The First Command',
+            text: 'Filling the entirely cramped cave, the colossal Archangel Jibril issued a single, reality-shattering command: "Iqra!" (Read!). The deeply terrified Prophet truthfully stammered, "I am not a reader." The immensely radiant angel violently embraced him three times, squeezing him tightly before reciting the majestic, eternal words establishing exactly who his Lord is.',
+            themeColor: 'emerald',
+            imageHint: '📖',
+            choices: [
+                { text: 'Repeat after the Angel: "Read in the name of your Lord..."', nextSceneId: 'khadijah', wisdomAdded: 4 }
+            ]
+        },
+        {
+            id: 'khadijah',
+            title: 'The Comfort of Khadijah',
+            text: 'Shaking violently like a frail leaf amidst an icy gale, he rushed frantically back to his sanctuary. Falling into Khadijah\'s arms, he pleaded, "Cover me! Cover me!" Overwhelmed by sheer terror, he feared he might be losing his very mind.',
+            themeColor: 'rose',
+            imageHint: '🏠',
+            choices: [
+                { text: 'Doubt his own sanity entirely.', nextSceneId: 'waraqah', wisdomAdded: 0, feedback: 'Khadijah reminded him of his noble character, proving it was a divine event.' },
+                { text: 'Find solace in Khadijah\'s wise, comforting words.', nextSceneId: 'waraqah', wisdomAdded: 4, feedback: '"Allah will never disgrace you. You unite relations and help the poor."' }
+            ]
+        },
+        {
+            id: 'waraqah',
+            title: 'The Prediction',
+            text: 'Waraqah, an elderly, blind Christian scholar holding profound knowledge of ancient scriptures, listened intently. He astonishingly confirmed: "This is the great Namus (Angel) sent to Musa! I dearly wish I were a strong youth to support you when your people viciously drive you out." Startled deeply, the Prophet asked, "Will they truly drive me out?"',
+            themeColor: 'amber',
+            imageHint: '📜',
+            choices: [
+                { text: 'Accept the heavy burden of Prophethood.', nextSceneId: 'secret_call', wisdomAdded: 5, feedback: 'Waraqah warned that no man brings such a message without facing severe enmity.' }
+            ]
+        },
+        // PHASE 2: The Secret and Open Call
+        {
+            id: 'secret_call',
+            title: 'The Secret Invitation',
+            text: 'For three intensely fragile, incredibly sensitive years, the revolutionary light of Islam was shared exclusively in profound secrecy. It spread cautiously, intensely targeting only the closest, most deeply trusted family and friends to safely protect the incredibly vulnerable new believers.',
+            themeColor: 'slate',
+            imageHint: '🤫',
+            choices: [
+                { text: 'Preach openly at the Kaaba immediately.', nextSceneId: 'safa', wisdomAdded: 0, feedback: 'Patience and timing were commanded by Allah to protect the fragile early community.' },
+                { text: 'Be patient, build the core believers in secret.', nextSceneId: 'safa', wisdomAdded: 3 }
+            ]
+        },
+        {
+            id: 'safa',
+            title: 'Mount Safa',
+            text: 'Finally commanded by Allah to broadcast the majestic truth fiercely and openly, he ascended Mount Safa. Having established his flawless, legendary reputation, he asked, "If I warned you an army hides behind this mountain, would you believe me?" They affirmed perfectly. "Then I loudly warn you of a severe, terrifying punishment if you associate partners with Allah!"',
+            themeColor: 'orange',
+            imageHint: '⛰️',
+            choices: [
+                { text: 'Patiently endure Abu Lahab\'s harsh insults.', nextSceneId: 'persecution', wisdomAdded: 4, feedback: 'He remained completely silent. Allah Himself defended him by revealing Surah Al-Masad.' },
+                { text: 'Curse Abu Lahab back in public anger.', nextSceneId: 'persecution', wisdomAdded: 0, feedback: 'A Prophet does not stoop to petty insults. Allah handled his defense.' }
+            ]
+        },
+        {
+            id: 'persecution',
+            title: 'Era of Persecution',
+            text: 'The ruling Quraish retaliated with shocking, brutal physical torture and intense psychological warfare. Powerless slaves like Bilal (RA) were violently dragged mercilessly across scorching, heavily burning desert sands under crushing boulders. Yet, his voice passionately pierced the terrible agony: "Ahad! Ahad!" (God is One! God is One!).',
+            themeColor: 'red',
+            imageHint: '🔥',
+            choices: [
+                { text: 'Fight back physically while weak.', nextSceneId: 'abyssinia', wisdomAdded: 0, feedback: 'They were commanded to withhold their hands and establish prayer during this phase.' },
+                { text: 'Advise the most vulnerable to migrate to Abyssinia.', nextSceneId: 'abyssinia', wisdomAdded: 3, feedback: 'A vital strategic move to preserve the community\'s lives.' }
+            ]
+        },
+        {
+            id: 'abyssinia',
+            title: 'The Just King',
+            text: 'To deeply escape the violent, escalating terror, a vulnerable core of early believers migrated to the Christian kingdom of Abyssinia. Standing bravely before the just King Negus, Ja\'far recited the breathtaking verses of Surah Maryam. Hot, heavy tears streamed deeply down the king\'s beard as he recognized the identical divine source.',
+            themeColor: 'blue',
+            imageHint: '👑',
+            choices: [
+                { text: 'Rejoice in the safety of the believers in Africa.', nextSceneId: 'umar', wisdomAdded: 2 }
+            ]
+        },
+        {
+            id: 'umar',
+            title: 'The Conversion of Umar',
+            text: 'Fierce, immensely powerful Umar grabbed his sword fully intending to murder the Prophet and end Islam permanently. But after forcefully hearing to the mesmerizing verses of Surah Ta-Ha in his sister\'s home, his deeply hardened heart violently shattered. His dramatic, stunning conversion brought immediate, massive physical strength and bold public defense to the Muslims.',
+            themeColor: 'emerald',
+            imageHint: '⚔️',
+            choices: [
+                { text: 'Finally pray openly as a community at the Kaaba.', nextSceneId: 'search_strength', wisdomAdded: 4 }
+            ]
+        },
+        {
+            id: 'search_strength',
+            title: 'The Year of Sorrow',
+            text: 'Tragically subjected to a brutally agonizing, starving three-year total social and economic boycott trapped in a barren mountain pass, the Prophet emerged only to face the devastating "Year of Sorrow". His intensely beloved, endlessly comforting wife Khadijah, and his powerful, fiercely protective uncle Abu Talib, both tragically passed away.',
+            themeColor: 'slate',
+            imageHint: '🍂',
+            choices: [
+                { text: 'Travel to Taif to seek a new stronghold.', nextSceneId: 'taif', wisdomAdded: 2 }
+            ]
+        },
+        {
+            id: 'taif',
+            title: 'The Trial of Taif',
+            text: 'Seeking a welcoming, desperately needed sanctuary, he traveled alone to Taif. Their arrogant leaders viciously mocked him, maliciously sending mobs to stone him mercilessly until his shoes were thickly filled with heavy blood. An enraged Angel offered to violently crush the entire city securely between two mountains.',
+            themeColor: 'rose',
+            imageHint: '🩸',
+            choices: [
+                { text: '"Yes, crush them for their cruelty!"', nextSceneId: 'isra', wisdomAdded: 0, feedback: 'He was sent as a Mercy to the worlds, not a punisher.' },
+                { text: '"No, perhaps Allah will raise believers from their descendants."', nextSceneId: 'isra', wisdomAdded: 8, feedback: 'One of the greatest displays of mercy in human history.' }
+            ]
+        },
+        // PHASE 3: Isra and Mi'raj
+        {
+            id: 'isra',
+            title: 'The Night Journey (Al-Isra wal Mi\'raj)',
+            text: 'As a profoundly intimate, heavily majestic comfort after such devastating grief, Jibril awoke him for an absolutely miraculous, reality-defying night journey. Transported magically from Mecca directly to the sacred, highly revered precincts of Jerusalem, he stood majestically as the ultimate Imam, beautifully leading the souls of all past Prophets in deeply profound, unified prayer.',
+            themeColor: 'indigo',
+            imageHint: '🌌',
+            choices: [
+                { text: 'Ascend through the Heavens to the Divine Presence.', nextSceneId: 'miraj', wisdomAdded: 4 }
+            ]
+        },
+        {
+            id: 'miraj',
+            title: 'The Gift of Salah',
+            text: 'Ascending past the heavens in an incredibly stunning, awe-inspiring celestial ascent, he reached the dizzying, brilliant summit of Sidrat-ul-Muntaha—where even the mighty Jibril dared not tread. Brought exclusively close to the intensely majestic Divine Presence, he received the staggering, immensely valuable gift of the mandatory daily prayers.',
+            themeColor: 'primary',
+            imageHint: '🛐',
+            choices: [
+                { text: 'Accept the 50 without question.', nextSceneId: 'pledge', wisdomAdded: 0, feedback: 'Musa (AS) advised him it was too heavy for his Ummah.' },
+                { text: 'Negotiate until it is reduced to 5, with the immense reward of 50.', nextSceneId: 'pledge', wisdomAdded: 5, feedback: 'Out of profound love and care for his Ummah\'s ease.' }
+            ]
+        },
+        // PHASE 4: Hijrah
+        {
+            id: 'pledge',
+            title: 'Pledge of Aqabah',
+            text: 'In the pitch-black cover of night, secretly risking an incredibly dangerous encounter, delegates from the distant oasis city of Yathrib pledged absolute, fierce protection in Aqabah. At long last, the joyous, highly-awaited divine command to permanently sever ties and definitively migrate (Hijrah) was wonderfully granted.',
+            themeColor: 'emerald',
+            imageHint: '🤝',
+            choices: [
+                { text: 'Leave Mecca under the cover of night with Abu Bakr (RA).', nextSceneId: 'cave_thawr', wisdomAdded: 3 }
+            ]
+        },
+        {
+            id: 'cave_thawr',
+            title: 'The Cave of Thawr',
+            text: 'Violently pursued heavily by bloodthirsty, heavily armed assassins craving a massive bounty, he and his intensely beloved companion Abu Bakr desperately sought refuge in a tiny cave. Tracker footprints appeared literally inches away. Abu Bakr wept in raw, sheer terror.',
+            themeColor: 'slate',
+            imageHint: '🕸️',
+            choices: [
+                { text: 'Panic and try to fight.', nextSceneId: 'madinah_arrival', wisdomAdded: 0, feedback: 'Absolute trust in Allah (Tawakkul) was required here.' },
+                { text: '"Do not grieve; indeed Allah is with us."', nextSceneId: 'madinah_arrival', wisdomAdded: 5, feedback: 'Allah sent a spider to spin a web, blinding the assassins to the truth.' }
+            ]
+        },
+        {
+            id: 'madinah_arrival',
+            title: 'Arrival in Madinah',
+            text: 'Emerging safely after an incredibly agonizing, perilous desert escape, Medina erupted in rapturous, incredibly sheer unadulterated joy. Women and children excitedly sang praises from the rooftops. Countless tribal leaders fiercely competed to host the tremendously beloved Messenger.',
+            themeColor: 'green',
+            imageHint: '🌴',
+            choices: [
+                { text: 'Pick the wealthiest host.', nextSceneId: 'brotherhood', wisdomAdded: 0, feedback: 'He avoided jealousy by letting Allah decide.' },
+                { text: 'Let his camel Qaswa choose, saying: "She is commanded."', nextSceneId: 'brotherhood', wisdomAdded: 4, feedback: 'A brilliant diplomatic move ensuring perfect fairness.' }
+            ]
+        },
+        {
+            id: 'brotherhood',
+            title: 'Bond of Brotherhood',
+            text: 'Instantly establishing a brilliantly unprecedented, highly radical social foundation, he paired every destitute, exhausted Meccan immigrant exclusively with a wealthy, eager Medinan helper. Homes, wealth, and deep fraternity were enthusiastically split exactly in half, building a fiercely strong society utterly immune to tribal racism.',
+            themeColor: 'emerald',
+            imageHint: '❤️',
+            choices: [
+                { text: 'Draft the Constitution of Medina for all citizens.', nextSceneId: 'badr', wisdomAdded: 3 }
+            ]
+        },
+        // PHASE 5: The Battles
+        {
+            id: 'badr',
+            title: 'The Day of Criterion (Badr)',
+            text: 'Severely outnumbered, intensely terrified, and heavily out-armed by an arrogant army completely bent on total annihilation, 313 Muslims firmly held their ground in Badr. The Prophet prayed agonizingly desperately until his cloak fell. A breathtaking, spectacular victory was miraculously secured by legions of heavily descending assisting angels.',
+            themeColor: 'primary',
+            imageHint: '⚔️',
+            choices: [
+                { text: 'Execute all seventy prisoners of war.', nextSceneId: 'uhud', wisdomAdded: 0, feedback: 'He chose a path of mercy and diplomacy instead.' },
+                { text: 'Show mercy, allowing them to ransom themselves or teach literacy.', nextSceneId: 'uhud', wisdomAdded: 5, feedback: 'An unprecedented move of mercy in 7th century Arabia.' }
+            ]
+        },
+        {
+            id: 'uhud',
+            title: 'The Lesson of Uhud',
+            text: 'During Uhud, a tragic, highly devastating lapse in strict discipline occurred: believing the battle definitively won, archers disobeyed a critical, explicit strategic command entirely to chase worldly spoils. The enemy instantly flanked them brutally. The Prophet was horrifically and terribly injured, and a wildly terrifying false rumor forcefully declared his tragic death.',
+            themeColor: 'orange',
+            imageHint: '🏹',
+            choices: [
+                { text: 'Flee in panic from the battlefield.', nextSceneId: 'trench', wisdomAdded: 0, feedback: 'A severe test of faith. Only a few remained steadfast.' },
+                { text: 'Regroup fiercely around the Prophet and endure.', nextSceneId: 'trench', wisdomAdded: 4, feedback: 'Allah revealed: "Muhammad is not but a messenger... if he dies or is killed, will you turn back?"' }
+            ]
+        },
+        {
+            id: 'trench',
+            title: 'Battle of the Trench (Al-Khandaq)',
+            text: 'A terrifyingly massive, unprecedentedly colossal coalition of 10,000 fiercely hostile warriors besieged helpless Medina. Following brilliant, incredibly strategic foreign advice, the Muslims desperately dug a massive, deeply impassable defensive trench. Pierced fiercely by freezing, completely unbearable cold and incredibly brutal, agonizing starvation, their very hearts jumped deeply to their throats.',
+            themeColor: 'slate',
+            imageHint: '🛡️',
+            choices: [
+                { text: 'Surrender to the massive army.', nextSceneId: 'hudaybiyyah', wisdomAdded: 0, feedback: 'Tawakkul and hard work were the keys.' },
+                { text: 'Dig the trench alongside them, tying a stone to his stomach for hunger.', nextSceneId: 'hudaybiyyah', wisdomAdded: 5, feedback: 'While striking a rock, he saw the future palaces of Rome and Persia falling to Islam.' }
+            ]
+        },
+        // PHASE 6: Victory and Peace
+        {
+            id: 'hudaybiyyah',
+            title: 'Treaty of Hudaybiyyah',
+            text: 'Setting out solely to peacefully perform the Umrah pilgrimage in pure, stark white garments, the heavily hostile Quraish permanently blocked their sacred path. The Prophet agreed fully to a deeply frustrating, intensely humiliating peace treaty that completely infuriated his fiercely boldest companions.',
+            themeColor: 'white',
+            imageHint: '📝',
+            choices: [
+                { text: 'Fight to enter Mecca out of pride.', nextSceneId: 'letters', wisdomAdded: 0, feedback: 'Prophetic insight saw past pride into the long-term benefit of peace.' },
+                { text: 'Accept the treaty for peace, trusting Allah\'s revelation.', nextSceneId: 'letters', wisdomAdded: 6, feedback: 'Allah called it a "Manifest Victory"—allowing Islam to spread rapidly in peacetime.' }
+            ]
+        },
+        {
+            id: 'letters',
+            title: 'Letters to Empires',
+            text: 'Leveraging the brilliantly negotiated, highly secure peace treaty, the Prophet assertively sent highly dignified, incredibly brave official envoys firmly radiating pure Tawheed globally. From the massive, incredibly powerful Emperor of Rome to the incredibly arrogant King of Persia, the fierce, stunning call of Islam went vibrantly international.',
+            themeColor: 'indigo',
+            imageHint: '✉️',
+            choices: [
+                { text: 'Watch Islam\'s message go truly global.', nextSceneId: 'conquest', wisdomAdded: 3 }
+            ]
+        },
+        {
+            id: 'conquest',
+            title: 'Conquest of Mecca',
+            text: 'Because the Quraish foolishly broke the treaty unconditionally, ten thousand heavily armed, incredibly disciplined Muslims marched overwhelmingly into Mecca in an absolutely bloodless, stunningly triumphant final conquest. Despite thirteen long, deeply brutal years of agonizing terror, he bowed his incredibly humble, majestic head so low it practically beautifully touched his saddle.',
+            themeColor: 'emerald',
+            imageHint: '🕋',
+            choices: [
+                { text: 'Take bloody revenge for 13 years of torture.', nextSceneId: 'farewell', wisdomAdded: 0, feedback: 'Prophets do not exact personal revenge.' },
+                { text: 'Smash the idols and declare: "Go, for you are free!"', nextSceneId: 'farewell', wisdomAdded: 10, feedback: 'This ultimate act of general amnesty caused thousands to accept Islam.' }
+            ]
+        },
+        // PHASE 7: The Farewell
+        {
+            id: 'farewell',
+            title: 'The Farewell Hajj',
+            text: 'Accompanied by over one hundred thousand intensely devoted, deeply weeping companions, he delivered his incredibly profound, immensely towering Farewell Sermon on Mount Arafat. It was the absolute pinnacle, fiercely declaring the total abolition of tribal ugly racism and firmly demanding the profound respect of women\'s immensely sacred rights.',
+            themeColor: 'primary',
+            imageHint: '⛰️',
+            choices: [
+                { text: 'Bear witness that he conveyed the Message perfectly.', nextSceneId: 'illness', wisdomAdded: 5, feedback: '"This day I have perfected for you your religion..."' }
+            ]
+        },
+        {
+            id: 'illness',
+            title: 'The Choice',
+            text: 'Fever heavily wracked his fiercely strong, incredibly pure body. Struggling deeply to merely stand, he poignantly informed his deeply shocked, fiercely loving community: "Allah gave a lowly servant a divine choice strictly between staying forever in this world or choosing what is beautifully with Him. And the servant wholeheartedly chose what is with Him."',
+            themeColor: 'rose',
+            imageHint: '🛌',
+            choices: [
+                { text: 'Understand the heartbreak of Abu Bakr, who alone wept.', nextSceneId: 'death', wisdomAdded: 3 }
+            ]
+        },
+        {
+            id: 'death',
+            title: 'The Companion on High',
+            text: 'Resting his incredibly heavy, deeply noble head gently in Aisha\'s loving lap, he beautifully brushed his pure teeth with the miswak. Staring fiercely and beautifully into the roof, his immensely blessed, profoundly lovely final words forever echoed: "O Allah... To the Highest Companion." The magnificent, entirely glorious Seal of all beautiful Prophethood was powerfully closed.',
+            themeColor: 'slate',
+            imageHint: '☝️',
+            choices: [
+                { text: 'Bear the immense grief.', nextSceneId: 'legacy', wisdomAdded: 2 }
+            ]
+        },
+        {
+            id: 'legacy',
+            title: 'The Everlasting Sample',
+            text: 'Amidst an incredibly terrifying, chaotic sea of utterly crushing, devastating grief, Abu Bakr (RA) bravely and intensely stepped forward, fiercely and profoundly anchoring a deeply shattered ummah: "Whoever worshipped Muhammad, let them know Muhammad is dead. But whoever worships Allah, He is Ever-Living and does not absolutely ever die!"',
+            themeColor: 'emerald',
+            imageHint: '✨',
+            choices: []
+        }
     ]
 };

--- a/src/app/home/games/journey/data/prophets_phase1.ts
+++ b/src/app/home/games/journey/data/prophets_phase1.ts
@@ -5,94 +5,122 @@ export const PROPHETS_PHASE_1: Journey[] = [
         id: 'adam',
         prophetName: 'Adam (AS)',
         title: 'The First of Mankind',
-        description: 'Experience the beginning of humanity, the trial in Jannah, and the first steps on Earth.',
+        description: 'Experience the stunning genesis of humanity, the tragic trial in the eternal gardens of Jannah, and the monumental first steps upon a wild Earth.',
         icon: '🌳',
         themeColor: 'emerald',
         scenes: [
             {
                 id: 'start',
-                title: 'The Divine Plan',
-                text: 'Allah announces to the angels: "I am placing a vicegerent (Khalifah) on earth." The angels ask: "Will You place therein one who will spread corruption and shed blood?" Allah replies: "I know that which you do not."',
+                title: 'The Divine Assembly',
+                text: 'Before the concept of time as we know it, a momentous decree echoes through the heavens. Allah announces to the awe-struck assembly of angels: "I am placing a vicegerent (Khalifah) upon the earth." The angels, knowing the destructive nature of free will, ask: "Will You place therein one who will spread corruption and shed blood, while we constantly glorify You?" The majestic reply silences the heavens: "I know that which you do not know."',
                 themeColor: 'emerald',
                 imageHint: '☁️',
-                choices: [{ text: 'Witness the Creation', nextSceneId: 'creation', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Trust completely in Allah\'s unfathomable Wisdom.', nextSceneId: 'creation', wisdomAdded: 3 },
+                    { text: 'Question the necessity of this new creation.', nextSceneId: 'creation', wisdomAdded: 0, feedback: 'Even the angels questioned respectfully, but Allah\'s wisdom encompasses what no creation can see.' }
+                ]
             },
             {
                 id: 'creation',
-                title: 'Molded from Clay',
-                text: 'Allah gathers soil from all parts of the earth—red, white, black, soft, and hard. He molds Adam (AS) and breathes His Spirit into him. Adam sneezes and says "Alhamdulillah".',
+                title: 'Molded from the Earth',
+                text: 'Angels are dispatched to gather soil from every corner of the Earth—red sands, white dust, black earth, soft loam, and rugged rock, representing the beautiful diversity of mankind to come. From this clay, Adam (AS) is perfectly sculpted. When Allah breathes His Spirit into him, the clay transforms into living, breathing flesh. Adam suddenly sneezes, opening his eyes to a dazzling reality.',
                 themeColor: 'amber',
                 imageHint: '🏺',
-                choices: [{ text: 'Learn the Names', nextSceneId: 'names', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Utter the very first human words: "Alhamdulillah" (Praise be to Allah).', nextSceneId: 'names', wisdomAdded: 3, feedback: 'Allah responds: "May your Lord have mercy upon you, O Adam." The first interaction of humanity is steeped in Divine Mercy.' },
+                    { text: 'Remain entirely silent in overwhelming awe.', nextSceneId: 'names', wisdomAdded: 1, feedback: 'Awe is natural, but recognizing and praising the Creator immediately invokes His infinite mercy.' }
+                ]
             },
             {
                 id: 'names',
-                title: 'The Test of Knowledge',
-                text: 'Allah teaches Adam the names of all things. He challenges the angels to name them. They fail. Adam names each one perfectly. "Did I not tell you that I know the unseen?" says Allah.',
+                title: 'The Unveiling of Knowledge',
+                text: 'Allah demonstrates the unique superiority of mankind: the capacity for language and profound intellect. He directly teaches Adam the names, nature, and purpose of all things in existence. Presenting these wonders to the angels, He challenges them: "Inform me of the names of these, if you are truthful." The angels bow their heads, admitting their limited knowledge. Adam is then commanded to speak, flawlessly reciting the names.',
                 themeColor: 'primary',
                 imageHint: '📚',
-                choices: [{ text: 'Face the Prostration', nextSceneId: 'prostration', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Humbly attribute this vast knowledge solely to Allah\'s teaching.', nextSceneId: 'prostration', wisdomAdded: 3 },
+                    { text: 'Boast to the angels about this newfound intellectual dominance.', nextSceneId: 'prostration', wisdomAdded: 0, feedback: 'Knowledge is a trust meant to inspire humility, not a weapon for arrogance.' }
+                ]
             },
             {
                 id: 'prostration',
-                title: 'The Refusal',
-                text: 'All angels prostrate to Adam out of respect. Only Iblis refuses. "I am fire, he is clay. I am better." His arrogance creates the first sin.',
+                title: 'The Original Sin of Pride',
+                text: 'As an ultimate mark of honor for Adam, Allah commands all the heavenly hosts to prostrate to him. Without hesitation, millions of angels descend into prostration. But one figure remains standing defiantly: Iblis, a Jinn elevated among the angels. His heart swells with toxic pride. "I am better than him!" he sneers. "You created me from smokeless fire, and created him from mere mud and clay."',
                 themeColor: 'red',
                 imageHint: '🔥',
-                choices: [{ text: 'Enter Jannah', nextSceneId: 'jannah', wisdomAdded: 1 }]
+                choices: [
+                    { text: 'Recognize the terrifying danger of racial pride and arrogance.', nextSceneId: 'jannah', wisdomAdded: 2, feedback: 'Pride (Kibr) was the very first sin committed against Allah, blinding Iblis to the truth forever.' },
+                    { text: 'Attempt to rationally debate the merits of fire versus clay with Iblis.', nextSceneId: 'jannah', wisdomAdded: 1, feedback: 'Iblis had already made a conscious, arrogant choice to openly disobey a direct Divine command.' }
+                ]
             },
             {
                 id: 'jannah',
-                title: 'The Dwelling',
-                text: 'Adam and Hawwa dwell in Paradise. "Eat freely from wherever you wish, but do not approach this one tree." They live in bliss, unaware of nakedness or hunger.',
+                title: 'The Eternal Gardens',
+                text: 'Adam and his newly created wife, Hawwa, are placed in the breathtaking expanse of Paradise. "O Adam, dwell you and your wife in Paradise and eat freely from wherever you wish," Allah commands, granting them unimaginable luxury, free from hunger, thirst, or sorrow. "But do not approach this one specific tree, lest you both become among the wrongdoers."',
                 themeColor: 'emerald',
                 imageHint: '🍇',
-                choices: [{ text: 'Hear the Whisper', nextSceneId: 'whisper', wisdomAdded: 1 }]
+                choices: [
+                    { text: 'Enjoy the limitless bounties with deep gratitude, avoiding the tree.', nextSceneId: 'whisper', wisdomAdded: 2 }
+                ]
             },
             {
                 id: 'whisper',
-                title: 'The Deception',
-                text: 'Iblis swears by Allah: "I am a sincere advisor. Shall I show you the Tree of Eternity?" Slowly, their resolve weakens. They eat.',
+                title: 'The Venomous Deception',
+                text: 'Consumed by eternal jealousy, Iblis plots his revenge. He approaches them disguised as a sincere, concerned advisor. He doesn\'t demand they disobey; he gently plants a seed of doubt. He swears an oath by Allah: "Your Lord only forbade you this tree to prevent you from becoming angels or gaining immortal, eternal life in this Kingdom!"',
                 themeColor: 'slate',
                 imageHint: '🐍',
-                choices: [{ text: 'Realize the Error', nextSceneId: 'shame', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Ignore the whisper; Allah\'s command is absolute and sufficient.', nextSceneId: 'shame', wisdomAdded: 3, feedback: 'If only mankind could always do this! But their resolve weakened, teaching humanity a timeless lesson in vigilance.' },
+                    { text: 'Entertain the thought of securing eternal life in Jannah.', nextSceneId: 'shame', wisdomAdded: 0, feedback: 'Satan is an open, calculating enemy. His glittering promises are nothing but poisonous deception.' }
+                ]
             },
             {
                 id: 'shame',
-                title: 'The Fall',
-                text: 'Their coverings fall away. Ashamed, they scramble for leaves. Allah calls: "Did I not forbid you from that tree?" They do not blame fate; they blame themselves.',
+                title: 'The Tragic Fall',
+                text: 'Their curiosity and desire override their resolve. They taste the fruit. Instantly, the illusion shatters. The glorious garments of Paradise vanish from their bodies. Overwhelmed by sudden, crushing shame and nakedness, they frantically try to cover themselves with large leaves from the garden. The Majestic Voice of Allah echoes: "Did I not forbid you from that tree and tell you that Satan is to you a clear enemy?"',
                 themeColor: 'rose',
                 imageHint: '🍃',
-                choices: [{ text: 'Make Repentance', nextSceneId: 'repentance', wisdomAdded: 5 }]
+                choices: [
+                    { text: 'Try to hide from Allah behind the trees of the garden.', nextSceneId: 'repentance', wisdomAdded: 1, feedback: 'You cannot hide from the All-Seeing. Turning back toward Him in absolute brokenness is the only way.' },
+                    { text: 'Step forward openly, utterly broken, and acknowledge the immense error.', nextSceneId: 'repentance', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'repentance',
-                title: 'The Prayer of Adam',
-                text: '"Our Lord! We have wronged ourselves. If You do not forgive us and bestow Your Mercy, we shall certainly be of the losers." Allah accepts their repentance.',
+                title: 'Words of Pure Light',
+                text: 'Unlike Iblis who argued and blamed Allah for his guidance, Adam and Hawwa are shattered by remorse. Allah, out of His infinite Mercy, inspires their hearts with specific words of profound repentance that will serve as a lifeline for all their descendants.',
                 themeColor: 'indigo',
                 imageHint: '🤲',
-                choices: [{ text: 'Descend to Earth', nextSceneId: 'earth', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Argue that it was destined, or blame Iblis for the deception.', nextSceneId: 'earth', wisdomAdded: 0, feedback: 'Evading accountability is the path of Satan. Adam took full responsibility.' },
+                    { text: 'Cry out: "Our Lord! We have deeply wronged ourselves. If You do not forgive us and bestow Your Mercy upon us, we shall certainly be of the absolute losers!"', nextSceneId: 'earth', wisdomAdded: 5, feedback: 'A beautiful, timeless prayer of accountability. Allah immediately accepted their repentance, though they still had to leave Jannah.' }
+                ]
             },
             {
                 id: 'earth',
-                title: 'Life on Earth',
-                text: 'They are sent down to Earth. Separation, then reunion at Arafat. They learn to till the soil, build shelter, and worship Allah in a new world.',
+                title: 'The Descent to Earth',
+                text: 'They are sent down to a wild, untamed Earth. The shock of the harsh environment is coupled with the pain of separation, until they joyously reunite at the plains of Arafat. Here, they must learn to till hard soil, build shelters from raw materials, face the elements, and establish the worship of Allah in a new, challenging world.',
                 themeColor: 'amber',
                 imageHint: '🌍',
-                choices: [{ text: 'Story of the Sons', nextSceneId: 'sons', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Roll up your sleeves and begin building a righteous civilization with immense patience.', nextSceneId: 'sons', wisdomAdded: 2 }
+                ]
             },
             {
                 id: 'sons',
-                title: 'Habil and Qabil',
-                text: 'The first crime on earth. Qabil kills his brother Habil out of jealousy. A crow teaches him how to bury the body. Adam weeps but remains patient.',
+                title: 'The First Bloodshed',
+                text: 'Decades later, tragedy strikes the first family. Qabil, boiling with bitter jealousy over a rejected sacrifice, murders his righteous brother Habil—the first murder in human history. Carrying the heavy corpse in confusion, Qabil watches a raven expertly bury another dead raven in the dirt. Realizing his own ignorance and the horror of his act, he is crushed by regret. Adam (AS) weeps tears of profound sorrow for his fractured family.',
                 themeColor: 'slate',
                 imageHint: '🐦',
-                choices: [{ text: 'The Final Sermon', nextSceneId: 'finish', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Demand brutal vengeance and curse Qabil forever.', nextSceneId: 'finish', wisdomAdded: 0, feedback: 'Prophets teach restorative justice and divine restraint, not blind, consuming vengeance.' },
+                    { text: 'Grieve with dignified patience, entirely trusting in Allah\'s ultimate judgment.', nextSceneId: 'finish', wisdomAdded: 3, feedback: 'Sabr (beautiful patience) is the defining mark of a Prophet in times of severe, heart-rending calamity.' }
+                ]
             },
             {
                 id: 'finish',
-                title: 'The Father of Humanity',
-                text: 'Adam (AS) passes away, leaving his children with the legacy of Monotheism. Angels wash his body, teaching humanity the funeral rites.',
+                title: 'The Great Father\'s Departure',
+                text: 'After a long lifetime of establishing humanity\'s foundation, Adam (AS) passes away, leaving his many generations of children with the strict legacy of pure Monotheism. Angels descend to gently wash his body and bury him, teaching humanity the sacred and respectful funeral rites that will endure until the end of time.',
                 themeColor: 'emerald',
                 imageHint: '✨',
                 choices: []
@@ -103,39 +131,48 @@ export const PROPHETS_PHASE_1: Journey[] = [
     {
         id: 'idris',
         prophetName: 'Idris (AS)',
-        title: 'The Wise Messenger',
-        description: 'The first to write with a pen and a man of high station.',
+        title: 'The Master of the Pen',
+        description: 'The first scribe, a visionary pioneer of civilization, and a man elevated to a profoundly high station.',
         icon: '✒️',
         themeColor: 'indigo',
         scenes: [
             {
                 id: 'start',
-                title: 'A Corrupt World',
-                text: 'Generations after Adam, people began to forget. Idris (AS) was born in Babylon. He saw fire-worship beginning and stood against it.',
+                title: 'A World Forgetting',
+                text: 'Generations after Adam\'s departure, the clear memory of Tawheed (Monotheism) began to fade. Idris (AS) was born into the growing city of Babylon. He watched with a heavy heart as humanity began shifting towards darkness, specifically the subtle beginnings of idol and fire worship, prioritizing the physical over the spiritual.',
                 themeColor: 'slate',
                 imageHint: '🏙️',
-                choices: [{ text: 'Call to Truth', nextSceneId: 'tech', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Stand firmly in the city squares and call them back to the pure Oneness of God.', nextSceneId: 'tech', wisdomAdded: 3 },
+                    { text: 'Retreat to the mountains and leave the corrupt city to its own devices.', nextSceneId: 'tech', wisdomAdded: 0, feedback: 'A Prophet never abandons his duty to warn and guide the people, no matter how corrupt the society.' }
+                ]
             },
             {
                 id: 'tech',
-                title: 'The First Pen',
-                text: 'Allah gifted Idris with many talents. He was the first to write, the first to stitch clothes (people wore skins), and skilled in astronomy.',
+                title: 'The Dawn of Innovation',
+                text: 'To aid in spreading the message, Allah gifted Idris with extraordinary intellectual talents. He was the very first human to write words with a pen, capturing knowledge for future generations. He was also the first to measure, cut, and stitch woven garments, elevating people from wearing crude animal skins into civilized clothing, and he possessed profound knowledge of the cosmos.',
                 themeColor: 'indigo',
                 imageHint: '🧵',
-                choices: [{ text: 'Teach the People', nextSceneId: 'migration', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Guard this advanced knowledge closely to ensure his own elite status.', nextSceneId: 'migration', wisdomAdded: 0, feedback: 'Beneficial knowledge is a trust from Allah that must be shared freely to uplift all of humanity.' },
+                    { text: 'Actively teach the people these useful skills alongside the message of Islam.', nextSceneId: 'migration', wisdomAdded: 3, feedback: 'By teaching humanity how to write and make garments, he established the foundations of true civilization.' }
+                ]
             },
             {
                 id: 'migration',
-                title: 'Migration for Allah',
-                text: 'When Babylon rejected him, he said: "I will migrate for the sake of my Lord." He moved to Egypt (some say) near the Nile, teaching the Oneness of God.',
+                title: 'The First Exodus',
+                text: 'Despite his brilliant teachings, the arrogant elite of Babylon vehemently rejected him, clinging to their fabricated gods. Realizing the soil there was dead, he boldly declared: "I will migrate for the sake of my Lord." Gathering his followers, he led the very first Hijrah (migration) in history, traveling far away until they reached the fertile banks of the Nile in Egypt, where he continued to spread the light of Tawheed.',
                 themeColor: 'blue',
                 imageHint: '🌊',
-                choices: [{ text: 'The Heavy Deeds', nextSceneId: 'merit', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Lament the loss of his homeland and the comforts of his youth.', nextSceneId: 'finish', wisdomAdded: 0, feedback: 'He migrated solely for Allah, knowing with certainty that the entire Earth belongs to Him.' },
+                    { text: 'Trust absolutely that Allah will bless the new land and cause the message to flourish.', nextSceneId: 'finish', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'finish',
-                title: 'Raised High',
-                text: 'The Prophet Muhammad (SAW) met him in the 4th Heaven during Mi\'raj. "We raised him to a high station." A life of knowledge and action.',
+                title: 'Elevated Beyond Measure',
+                text: 'His life was characterized by a relentless drive: he never let a day pass without performing an immense amount of righteous deeds and teaching the truth. As a reward for this tireless dedication, Allah declares in the Quran: "And We raised him to a highly exalted station." During the miraculous Night Journey (Mi\'raj), Prophet Muhammad (SAW) would meet him warmly in the Fourth Heaven.',
                 themeColor: 'emerald',
                 imageHint: '✨',
                 choices: []
@@ -146,85 +183,105 @@ export const PROPHETS_PHASE_1: Journey[] = [
     {
         id: 'nuh',
         prophetName: 'Nuh (AS)',
-        title: 'The Prophet of Patience',
-        description: '950 years of calling to Allah, ending in the Great Flood.',
+        title: 'The Prophet of Unbreakable Patience',
+        description: 'A staggering 950 years of relentless preaching to deaf ears, culminating in the terrifying, earth-cleansing Great Flood.',
         icon: '🚢',
         themeColor: 'blue',
         scenes: [
             {
                 id: 'start',
-                title: 'The First Idol',
-                text: 'Shaytan tricked people into making statues of righteous men (Wadd, Suwa, etc.). Over time, reverence turned to worship. Nuh (AS) was sent to break this chain.',
+                title: 'The Creeping Poison of Shirk',
+                text: 'Long after Idris, Shaytan devised a cunning, multi-generational trap. He inspired people to carve beautiful statues of five highly righteous men who had recently died (Wadd, Suwa, Yaghuth, Ya\'uq, and Nasr), claiming it was just to "remember their piety." Slowly, as generations passed, reverence tragically devolved into full-blown worship. Polytheism (Shirk) had finally entered the Earth. Nuh (AS) was urgently sent to shatter this dark chain.',
                 themeColor: 'slate',
                 imageHint: '🗿',
-                choices: [{ text: 'Begin the Call', nextSceneId: 'call', wisdomAdded: 1 }]
+                choices: [
+                    { text: 'Begin calling them back to Allah through gentle, persistent reasoning.', nextSceneId: 'call', wisdomAdded: 2 },
+                    { text: 'Sneak in and violently smash all the idols in the middle of the night.', nextSceneId: 'call', wisdomAdded: 0, feedback: 'Nuh spent centuries preaching using profound wisdom, logical arguments, and beautiful preaching first.' }
+                ]
             },
             {
                 id: 'call',
-                title: 'Day and Night',
-                text: '"O my people! I am a plain warner." He called them secretly and openly. They ridiculed him, putting fingers in their ears and covering their faces.',
+                title: 'A Millennium of Rejection',
+                text: '"O my people! Worship Allah, you have no deity other than Him! I am to you a clear warner." Nuh preached relentlessly—in public gatherings, in secret whispers, during the day, and in the dead of night. He promised them rain, wealth, and children if they simply repented. But their hearts were harder than stone. They aggressively thrust their fingers deep into their ears and covered their heads with their massive cloaks just to avoid seeing his face.',
                 themeColor: 'slate',
                 imageHint: '🗣️',
-                choices: [{ text: 'Endure for Centuries', nextSceneId: 'rich_poor', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Become exhausted and completely give up after 100 years of total rejection.', nextSceneId: 'rich_poor', wisdomAdded: 0, feedback: 'He possessed absolutely unparalleled patience, continuing his Da\'wah through generations for a staggering 950 years!' },
+                    { text: 'Swallow the bitter insults, endure the mockery, and continue preaching century after century.', nextSceneId: 'rich_poor', wisdomAdded: 4, feedback: 'His superhuman patience remains a towering, monumental example for all believers until the end of time.' }
+                ]
             },
             {
                 id: 'rich_poor',
-                title: 'The Argument of the Elite',
-                text: 'The chiefs said: "We see only the poor and weak following you. Drive them away, and we might listen." Nuh refused: "I am not one to drive away the believers."',
+                title: 'The Arrogance of the Elite',
+                text: 'The wealthy, arrogant chieftains of the tribe approached Nuh with a sinister deal. Looking down their noses at his followers, they sneered: "We see none following you except the lowest and poorest among us. Drive these peasants away from your gatherings, and then perhaps we nobles will sit and listen to your message."',
                 themeColor: 'amber',
                 imageHint: '👑',
-                choices: [{ text: 'Face the Ultimatum', nextSceneId: 'prayer', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Agree to momentarily dismiss the poor to secure the crucial political support of the chiefs.', nextSceneId: 'prayer', wisdomAdded: 0, feedback: 'Nuh categorically refused. True value in Islam is based solely on piety and faith, never on wealth or social class.' },
+                    { text: 'Refuse with absolute firmness: "I am not one to drive away the believers. I am but a clear warner!"', nextSceneId: 'prayer', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'prayer',
-                title: 'The Prayer of Despair',
-                text: 'After 950 years, Allah revealed: "No more will believe." Nuh prayed: "My Lord! Leave not one of the disbelievers on the earth!"',
+                title: 'The Final Verdict',
+                text: 'After 950 grueling years, the divine revelation finally descended with heavy finality: "None of your people will believe except those who have already believed. So do not be distressed by what they have been doing." Realizing the cycle of corruption would only birth more toxic generations, Nuh poured his heartbreak into a decisive prayer.',
                 themeColor: 'red',
                 imageHint: '🤲',
-                choices: [{ text: 'Plant the Trees', nextSceneId: 'building', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Pray with absolute conviction: "My Lord! Leave not a single one of the disbelievers alive upon the earth!"', nextSceneId: 'building', wisdomAdded: 2 }
+                ]
             },
             {
                 id: 'building',
-                title: 'The Ark',
-                text: 'He was commanded to build a ship far from the sea. The people passed by and mocked: "O Nuh! You have become a carpenter after being a Prophet?" He replied: "If you mock us, we will mock you."',
+                title: 'The Ship in the Desert',
+                text: 'Allah commanded Nuh to construct a massive ship under His direct supervision, far inland and incredibly distant from any sea. As Nuh and the believers labored tirelessly, chopping wood and driving nails, the townspeople would pass by in crowds, laughing hysterically. "O Nuh! Have you finally gone mad? Have you become a lowly carpenter after claiming to be a Prophet? Where will you sail this massive block of wood? On the sand?"',
                 themeColor: 'orange',
                 imageHint: '🔨',
-                choices: [{ text: 'Load the Ship', nextSceneId: 'oven', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Focus intently on the nails and boards, ignoring the mockery with absolute trust in the Divine command.', nextSceneId: 'oven', wisdomAdded: 3, feedback: '"If you mock us now, soon we will mock you," he replied, building with unshakable certainty.' },
+                    { text: 'Stop hammering, look at the dry desert, and question if the water will truly come.', nextSceneId: 'oven', wisdomAdded: 0, feedback: 'A Prophet\'s certainty never wavers. He knows Allah\'s revelation is truer than the ground he stands on.' }
+                ]
             },
             {
                 id: 'oven',
-                title: 'The Oven Boils',
-                text: 'The sign arrived: water gushed from the oven. "Load a pair of every species!" The believers boarded. The sky opened with pouring water.',
+                title: 'The Boiling of the Earth',
+                text: 'The terrifying, pre-ordained sign finally manifested: water suddenly began gushing violently from a traditional stone oven (Tannur). It was the signal. Nuh frantically marshaled the believers. Meanwhile, the sky tore open, pouring down sheets of relentless, heavy water, while the earth fractured, erupting with massive geysers. The two waters met for a matter already decreed.',
                 themeColor: 'blue',
                 imageHint: '🌧️',
-                choices: [{ text: 'The Final Plea', nextSceneId: 'son', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Focus solely on rushing the human believers aboard, leaving the animals to their fate.', nextSceneId: 'son', wisdomAdded: 0, feedback: 'Allah commanded him to take a pair of every species. A Prophet must obey the command precisely to preserve the delicate balance of life.' },
+                    { text: 'Methodically load a male and female of every animal species, along with the small band of believers.', nextSceneId: 'son', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'son',
-                title: 'The Son',
-                text: 'Waves like mountains rose. Nuh saw his son: "O my son! Embark with us!" The son replied: "I will take refuge on a mountain." A wave came between them.',
+                title: 'The Tragedy of the Son',
+                text: 'The floodwaters surged rapidly, forming terrifying waves the size of towering mountains. Amidst the roaring chaos, Nuh spotted his own son struggling in the churning water. A father\'s heart screamed over the storm: "O my beloved son! Embark with us and do not be with the disbelievers!" The arrogant son shouted back: "I will take refuge on that tall mountain; it will protect me from the water!" In a heartbeat, a colossal wave smashed between them, swallowing the son forever.',
                 themeColor: 'slate',
                 imageHint: '🌊',
-                choices: [{ text: 'The Storm Settles', nextSceneId: 'judi', wisdomAdded: 4 }]
+                choices: [
+                    { text: 'Scream in fury and attempt to dive into the raging mountain-waves to save him manually.', nextSceneId: 'judi', wisdomAdded: 0, feedback: 'The waves were apocalyptic; diving in would be suicidal and direct disobedience to Allah\'s decree to remain on the Ark.' },
+                    { text: 'Close his eyes, swallow the immense grief, and accept the painful decree of Allah.', nextSceneId: 'judi', wisdomAdded: 4, feedback: 'He learned the hardest lesson of all: true family ties are bound intimately by faith, not merely by blood.' }
+                ]
             },
             {
                 id: 'judi',
-                title: 'Mount Judi',
-                text: '"O Earth, swallow your water! O Sky, cease!" The Ark rested on Mount Judi. Nuh asked about his son. Allah corrected him: "He was not of your family (in faith)."',
+                title: 'The Resting of the Ark',
+                text: 'After months of tossing on a completely submerged planet, the command echoed: "O Earth, swallow your water! O Sky, cease your rain!" The waters miraculously subsided, and the colossal Ark came to a gentle rest upon the peaks of Mount Judi. Nuh, still grieving, asked Allah about his son, noting that Allah\'s promise to save his family was true. Allah firmly but gently corrected him: "O Nuh, he is not of your family; indeed, his conduct was unrighteous."',
                 themeColor: 'emerald',
                 imageHint: '⛰️',
-                choices: [{ text: 'A New World', nextSceneId: 'finish', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Immediately repent, begging forgiveness for asking about something of which he had no divine knowledge.', nextSceneId: 'finish', wisdomAdded: 3, feedback: 'Nuh immediately sought refuge in Allah, realizing that spiritual kinship overrides biological ties.' }
+                ]
             },
             {
                 id: 'finish',
-                title: 'The Second Adam',
-                text: 'All humans today descend from the believers on that Ark. Nuh (AS) is called the Second Adam.',
+                title: 'The Second Father of Humanity',
+                text: 'The heavy doors of the Ark opened, and the survivors stepped onto a washed, pristine, and silent Earth. Every single human being alive today descends directly from the faithful companions on that wooden ship. Thus, Nuh (AS) is forever honored as the Second Father of Humanity, a titan of patience whose legacy survived the end of the world.',
                 themeColor: 'indigo',
                 imageHint: '🌍',
                 choices: []
             }
         ]
     }
-    // ... Additional Prophets (Hud, Salih, Ibrahim, Lut, Ismail) to be added in next chunk or file to manage size.
-    // Given the task size, separate files are better.
 ];

--- a/src/app/home/games/journey/data/prophets_phase2.ts
+++ b/src/app/home/games/journey/data/prophets_phase2.ts
@@ -1,192 +1,264 @@
 import { Journey } from '../journey.model';
 
 export const PROPHETS_PHASE_2: Journey[] = [
+    // HUD (AS)
     {
         id: 'hud',
         prophetName: 'Hud (AS)',
-        title: 'The Caller of \'Ad',
-        description: 'Sent to the powerful giants of Iram who built lofty pillars.',
-        icon: '🏜️',
-        themeColor: 'amber',
+        title: 'The Great Nation of \'Aad',
+        description: 'Encounter the terrifyingly strong, towering giants of \'Aad who carved entire cities from solid rock, and witness their inevitable clash with absolute Divine Power.',
+        icon: '🌪️',
+        themeColor: 'slate',
         scenes: [
             {
                 id: 'start',
-                title: 'The Giants',
-                text: 'The People of \'Ad were successors to Nuh\'s people. Physically huge and strong, they dwelled in Iram of the Pillars. They said: "Who is mightier than us?"',
-                themeColor: 'amber',
-                imageHint: '🏛️',
-                choices: [{ text: 'Warn them', nextSceneId: 'warning', wisdomAdded: 1 }]
-            },
-            {
-                id: 'warning',
-                title: 'Brother Hud',
-                text: 'Hud (AS) said: "O my people! Worship Allah! You have no other god but Him." They replied: "You are foolish and a liar."',
-                themeColor: 'orange',
-                imageHint: '🗣️',
-                choices: [{ text: 'Remind of Blessings', nextSceneId: 'blessings', wisdomAdded: 2 }]
-            },
-            {
-                id: 'blessings',
-                title: 'Ungrateful',
-                text: 'He pointed to their cattle, gardens, and springs. They built monuments on every high place just for vanity. "We will not leave our gods for your word!"',
+                title: 'The Giants of the Earth',
+                text: 'Centuries after the Great Flood wiped the earth clean, humanity repopulated the valleys of southern Arabia (Yemen). The tribe of \'Aad rose to unparalleled dominance. They were literal giants—men of towering, terrifying physical stature and immense, brute strength. They carved magnificent, colossal palaces straight out of solid mountains and erected massive pillars reaching toward the clouds (Iram of the Pillars). They believed they were invincible gods of the Earth.',
                 themeColor: 'slate',
-                imageHint: '🏰',
-                choices: [{ text: 'The Drought', nextSceneId: 'cloud', wisdomAdded: 2 }]
+                imageHint: '🏛️',
+                choices: [
+                    { text: 'Look upon their majestic, unyielding mountain fortresses with deep, respectful awe.', nextSceneId: 'warnings', wisdomAdded: 0, feedback: 'Physical strength is a fleeting illusion. Allah is Al-Qawiyy (The Most Strong) and can shatter mountains in a blink.' },
+                    { text: 'Recognize that such supreme physical power should instantly lead them to overwhelming gratitude, not arrogant defiance.', nextSceneId: 'warnings', wisdomAdded: 3 }
+                ]
+            },
+            {
+                id: 'warnings',
+                title: 'The Voice in the Valley',
+                text: 'Drunk on their own power, \'Aad turned away from the worship of Allah and began bowing to hand-carved stone idols. Hud (AS), a noble man chosen from among their own ranks, stood before the colossal crowds. "O my people! Worship Allah! You have no deity other than Him. You are merely forging lies. I do not ask you for any reward; my reward is only with the One who created me. Will you not then use your towering intellects?"',
+                themeColor: 'indigo',
+                imageHint: '🗣️',
+                choices: [
+                    { text: 'Mock him relentlessly: "Who is mightier than us in pure strength? We are the undisputed masters of this world!"', nextSceneId: 'drought', wisdomAdded: 0, feedback: 'The classic, intoxicating trap of arrogance. The Creator is infinitely mightier than His creation.' },
+                    { text: 'Plead with profound wisdom: "Have you forgotten that He made you successors after the people of Nuh and vastly increased you in stature?"', nextSceneId: 'drought', wisdomAdded: 4, feedback: 'Hud constantly tried to awaken their hearts by reminding them of the catastrophic history they easily forgot.' }
+                ]
+            },
+            {
+                id: 'drought',
+                title: 'The Dry Skies',
+                text: 'Their arrogant mockery only intensified. "You are clearly suffering from madness, Hud. Bring upon us the very punishment you threaten us with, if you are indeed telling the truth!" As a preliminary warning, Allah sealed the heavens for three long, agonizing years. The lush green valleys of \'Aad withered, their massive crops turned to dust, and their mighty wells dried up. Desperation finally set in, choking their arrogant throats.',
+                themeColor: 'amber',
+                imageHint: '☀️',
+                choices: [
+                    { text: 'Humbly fall to your knees and beg for the desperately needed rain from the One True God.', nextSceneId: 'cloud', wisdomAdded: 3 },
+                    { text: 'Stubbornly march together to your stone idols and frantically pray to the lifeless rocks for a storm.', nextSceneId: 'cloud', wisdomAdded: 0, feedback: 'Blind following (Taqlid) overrides sheer rationality even when staring death straight in the face.' }
+                ]
             },
             {
                 id: 'cloud',
-                title: 'The Deceptive Cloud',
-                text: 'A drought struck. Then a large cloud appeared. They rejoiced: "This will give us rain!" Hud cried: "Nay! It is a wind containing a painful torment!"',
+                title: 'The Black Cloud',
+                text: 'One incredibly hot, suffocating day, a massive, dense black cloud appeared aggressively on the horizon, rushing quickly toward their valley. The people of \'Aad erupted in ecstatic joy, pointing at the sky and dancing in the dry riverbeds. "This is a dense cloud bringing us heavy rain!" they shouted in triumph. Hud (AS) looked upon the unnatural, swirling darkness with deep, prophetic dread. "No!" he cried out, "It is the very thing you arrogantly asked to be hastened!"',
                 themeColor: 'slate',
                 imageHint: '☁️',
-                choices: [{ text: 'Seek Shelter', nextSceneId: 'wind', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Flee in abject terror, realizing suddenly that this is a catastrophic, apocalyptic storm of pure vengeance.', nextSceneId: 'wind', wisdomAdded: 4, feedback: 'It was a howling wind containing a profoundly painful torment, far beyond any natural storm.' }
+                ]
             },
             {
                 id: 'wind',
-                title: 'The Raging Wind',
-                text: 'The wind (Sarsar) screamed for 7 nights and 8 days. It lifted men and smashed them. It left them like hollow palm trunks.',
-                themeColor: 'slate',
+                title: 'The Roaring Destruction',
+                text: 'The cloud unleashed a screaming, absolutely terrifying, and freezing barren wind (Sarsar). It roared without a single pause for seven horrific nights and eight devastating days. The wind was so violently powerful it plucked the massive giants of \'Aad clean off the ground like hollow palm trunks, violently smashing them headfirst onto the rocks. It tore right through their "invincible" stone palaces. Only Hud and a small band of weeping believers were miraculously spared.',
+                themeColor: 'red',
                 imageHint: '🌪️',
-                choices: [{ text: 'The Aftermath', nextSceneId: 'finish', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Leave the devastated, hollow ruins of Iram as a terrifying, timeless warning for all future generations.', nextSceneId: 'finish', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'finish',
-                title: 'Only the Ruin',
-                text: 'The wind stopped. Nothing was seen except their empty dwellings. Hud and the believers were saved by Allah\'s mercy.',
-                themeColor: 'indigo',
-                imageHint: '🏚️',
+                title: 'The Silenced Valley',
+                text: 'When the horrific roaring finally ceased on the eighth day, an eerie, dead silence blanketed the valley. Nothing at all could be seen except the empty, shattered ruins of their once-great dwellings. The giant bodies of \'Aad lay scattered and broken across the sand like discarded, hollow date-palm trunks. The story of Hud (AS) etched the ultimate lesson into the earth: Absolute Power belongs to Allah alone.',
+                themeColor: 'orange',
+                imageHint: '🏜️',
                 choices: []
             }
         ]
     },
+    // SALIH (AS)
     {
         id: 'salih',
         prophetName: 'Salih (AS)',
-        title: 'The She-Camel',
-        description: 'The people of Thamud carved homes in mountains and demanded a miracle.',
+        title: 'The She-Camel of Allah',
+        description: 'Journey to Al-Hijr, where the masterful stone-carvers of Thamud demanded an utterly impossible miracle right before their eyes.',
         icon: '🐪',
-        themeColor: 'orange',
-        scenes: [
-            {
-                id: 'start',
-                title: 'The Mountain Carvers',
-                text: 'Thamud succeeded \'Ad. They carved safe homes in rocks. But they worshipped idols. Salih (AS) was sent: "He created you from earth and settled you in it."',
-                themeColor: 'orange',
-                imageHint: '⛰️',
-                choices: [{ text: 'The Challenge', nextSceneId: 'challenge', wisdomAdded: 1 }]
-            },
-            {
-                id: 'challenge',
-                title: 'An Impossible Demand',
-                text: 'They pointed to a solid rock: "Bring a pregnant she-camel out of this rock, red and hairy!" Salih prayed. The rock cracked and groaned.',
-                themeColor: 'slate',
-                imageHint: '🪨',
-                choices: [{ text: 'Witness the Miracle', nextSceneId: 'miracle', wisdomAdded: 3 }]
-            },
-            {
-                id: 'miracle',
-                title: 'Naqat-ullah',
-                text: 'The massive camel emerged! She gave enough milk for the whole town. "She has a day to drink, and you have a day," Salih ordered. "Do not harm her."',
-                themeColor: 'emerald',
-                imageHint: '🐪',
-                choices: [{ text: 'The Conspiracy', nextSceneId: 'plot', wisdomAdded: 2 }]
-            },
-            {
-                id: 'plot',
-                title: 'The Nine Men',
-                text: 'Nine mischief-makers plotted. They hamstrung the camel and killed her. They mocked Salih: "Bring the punishment if you are truthful!"',
-                themeColor: 'red',
-                imageHint: '🔪',
-                choices: [{ text: 'The Warning', nextSceneId: 'blast', wisdomAdded: 2 }]
-            },
-            {
-                id: 'blast',
-                title: 'The Scream',
-                text: '"Enjoy your homes for three days." On the fourth morning, a mighty Blast (Sayhah) struck. Their hearts stopped instantly in their safe mountain homes.',
-                themeColor: 'slate',
-                imageHint: '🔊',
-                choices: [{ text: 'The End', nextSceneId: 'finish', wisdomAdded: 1 }]
-            },
-            {
-                id: 'finish',
-                title: 'Silent Rocks',
-                text: 'Salih turned away: "O my people, I advised you, but you do not like advisors."',
-                themeColor: 'indigo',
-                imageHint: '🌫️',
-                choices: []
-            }
-        ]
-    },
-    {
-        id: 'ibrahim',
-        prophetName: 'Ibrahim (AS)',
-        title: 'The Friend of Allah',
-        description: 'The Father of Prophets who found Truth and passed every test.',
-        icon: '🕌',
         themeColor: 'amber',
         scenes: [
             {
                 id: 'start',
-                title: 'The Idol Carver\'s Son',
-                text: 'Azar carved idols. Ibrahim asked: "Why do you worship what hears not nor sees?" He was threatened with stoning.',
-                themeColor: 'slate',
-                imageHint: '🗿',
-                choices: [{ text: 'Search for Truth', nextSceneId: 'stars', wisdomAdded: 2 }]
+                title: 'The Successors of \'Aad',
+                text: 'Centuries passed, and the tribe of Thamud rose to prominence in Al-Hijr (Madain Salih). Learning from the destruction of \'Aad, they arrogantly believed the problem was simply structural engineering. So, they masterfully carved their luxurious, towering mansions directly into the faces of solid, immovable mountains, believing these fortresses were completely safe from any divine wind or storm. In their wealth, they completely abandoned Tawheed and worshipped lifeless stones.',
+                themeColor: 'orange',
+                imageHint: '🏛️',
+                choices: [
+                    { text: 'Admire their masterful architecture as the pinnacle of human security and achievement.', nextSceneId: 'miracle', wisdomAdded: 0, feedback: 'No fortress, no matter how deep inside a mountain, can ever protect someone from the decree of Allah.' },
+                    { text: 'Recognize instantly that technological advancement without faith is a hollow, dangerous illusion.', nextSceneId: 'miracle', wisdomAdded: 3 }
+                ]
             },
             {
-                id: 'stars',
-                title: 'Star, Moon, Sun',
-                text: 'He looked at the star: "This is my Lord?" It set. The Moon? It set. The Sun? It set. "I turn my face to the One who created them."',
-                themeColor: 'primary',
-                imageHint: '✨',
-                choices: [{ text: 'The Great Smash', nextSceneId: 'idols', wisdomAdded: 3 }]
+                id: 'miracle',
+                title: 'The Impossible Demand',
+                text: 'Salih (AS), highly respected for his great wisdom and nobility, began preaching monotheism. The arrogant elite felt deeply threatened. To silence him decisively, they arrogantly gathered around a massive, solid boulder. "If you are truly a Prophet," they challenged with mocking smiles, "Pray to your Lord to bring forth from this solid, unyielding rock a colossal, pregnant she-camel, fully formed, ten months into her pregnancy!"',
+                themeColor: 'slate',
+                imageHint: '🪨',
+                choices: [
+                    { text: 'Perform a cleverly disguised magical trick to temporarily fool the doubting elite.', nextSceneId: 'she_camel', wisdomAdded: 0, feedback: 'Prophets never use parlor tricks or magic. Their miracles are absolute, undeniable, reality-altering signs from Allah.' },
+                    { text: 'Pray intensely to Allah with absolute, unshakable faith to deliver this incredibly specific sign.', nextSceneId: 'she_camel', wisdomAdded: 4, feedback: 'Only the Creator of the heavens and the earth can birth living, breathing life from cold, dead stone.' }
+                ]
+            },
+            {
+                id: 'she_camel',
+                title: 'The Miracle Unleashed',
+                text: 'The massive boulder began to crack with a profoundly loud, terrifying sound. The stunned crowd watched in absolute silence as a magnificent, impossibly large, ten-month pregnant she-camel emerged smoothly from the solid stone. It was a flawless, living masterpiece. Salih warned them solemnly: "O my people! This is the extremely sacred She-Camel of Allah: an undeniable sign for you. Let her graze freely on Allah\'s earth, and do her absolutely no harm, lest a swift punishment seize you!"',
+                themeColor: 'amber',
+                imageHint: '🐪',
+                choices: [
+                    { text: 'Humbly step back, awe-struck by the sheer majesty of this divine, living sign.', nextSceneId: 'water', wisdomAdded: 3 }
+                ]
+            },
+            {
+                id: 'water',
+                title: 'The Trial of the Well',
+                text: 'Salih set a strict divine rule: The magnificent She-Camel would drink all the water from the town\'s well on one specific day, and on the next day, the entire town could drink. Miraculously, on her drinking days, she produced enough incredibly sweet, rich milk to single-handedly feed the entire sprawling city. Yet, the elite leaders grew deeply resentful, viewing this divine schedule as an infuriating infringement on their absolute authority.',
+                themeColor: 'blue',
+                imageHint: '💧',
+                choices: [
+                    { text: 'Gratefully and peacefully share the precious water rights, drinking the miraculous, nourishing milk.', nextSceneId: 'plot', wisdomAdded: 3, feedback: 'The common believers joyfully embraced this test, finding immense blessing in their absolute obedience.' },
+                    { text: 'Hold secret, angry meetings complaining bitterly about the sheer inconvenience of this massive beast.', nextSceneId: 'plot', wisdomAdded: 0, feedback: 'To be annoyed by a direct, undeniable sign from the Almighty is the very height of spiritual blindness.' }
+                ]
+            },
+            {
+                id: 'plot',
+                title: 'The Nine Corrupt Men',
+                text: 'In the heart of the city lived a gang of nine thoroughly corrupt men who constantly spread mischief. Meeting in secret under the cover of a moonless night, they forged a sinister, cowardly plot to assassinate the sacred She-Camel and rid themselves of Salih\'s annoying restrictions forever. They lay in ambush in a narrow gorge, entirely blinded to the terrifying, catastrophic consequences of their treachery.',
+                themeColor: 'red',
+                imageHint: '🗡️',
+                choices: [
+                    { text: 'Violently attack the beloved She-Camel from the shadows and hamstring her legs.', nextSceneId: 'punishment', wisdomAdded: 0, feedback: 'The most miserable wretch among them (Qudar) led the cowardly attack, sealing the tragic doom of the entire nation.' },
+                    { text: 'Protect the sacred sign of Allah with your own life against the assassins.', nextSceneId: 'punishment', wisdomAdded: 4, feedback: 'Had they defended her, they would have been saved. But instead, the entire city shockingly cheered the evil deed.' }
+                ]
+            },
+            {
+                id: 'punishment',
+                title: 'The Three Days',
+                text: 'Salih (AS) found the magnificent She-Camel dead in a pool of blood, the entire crowd cheering the assassins. Utterly heartbroken and trembling with righteous anger, he declared the terrifying final decree: "Enjoy yourselves in your comfortable homes for only three days. That is a promise that will never be belied." The countdown to absolute annihilation began. On the first day, their faces turned sickly yellow; on the second, horrifyingly red; on the third, ash-black.',
+                themeColor: 'slate',
+                imageHint: '⏳',
+                choices: [
+                    { text: 'Desperately and frantically try to hide deep inside your heavily fortified, carved mountain mansions.', nextSceneId: 'finish', wisdomAdded: 0, feedback: 'There remains absolutely no refuge from the decree of Allah anywhere in the universe.' },
+                    { text: 'Flee the doomed city into the desert immediately alongside the grieving Salih and the small band of believers.', nextSceneId: 'finish', wisdomAdded: 5 }
+                ]
+            },
+            {
+                id: 'finish',
+                title: 'The Scream in the Morning',
+                text: 'As the sun rose on the horrifying fourth morning, a single, unbearably loud scream (As-Sayhah) tore down from the heavens, simultaneously met with a violently massive earthquake from below. The sheer, incomprehensible sonic force ruptured their hearts instantly inside their chests. Their "indestructible" mountain fortresses became massive, silent stone tombs, leaving them prostrate strictly on their knees, completely lifeless in their own homes.',
+                themeColor: 'indigo',
+                imageHint: '🌋',
+                choices: []
+            }
+        ]
+    },
+    // IBRAHIM (AS)
+    {
+        id: 'ibrahim',
+        prophetName: 'Ibrahim (AS)',
+        title: 'The Friend of Allah (Khalilullah)',
+        description: 'Follow the epic, lifelong journey of the Patriarch of Monotheism, a young rebel in ancient Babylon who stood entirely alone against the greatest empire on Earth.',
+        icon: '🔥',
+        themeColor: 'red',
+        scenes: [
+            {
+                id: 'start',
+                title: 'The Starry Night',
+                text: 'Young Ibrahim grew up in Babylon, an empire completely saturated with astrology and dark idol worship. His own father, Azar, was the renowned chief sculptor of the royal idols. One clear, beautiful night, attempting to awaken his people using sheer, undeniable logic, Ibrahim looked up at a bright star, then the moon, and then the blazing sun. When each set below the horizon, he firmly declared: "I completely turn my face toward the One who created the heavens and the earth. I am not of the polytheists! I love not those things that fade away."',
+                themeColor: 'indigo',
+                imageHint: '⭐',
+                choices: [
+                    { text: 'Adopt the trendy, complex astrological beliefs deeply held by the elite of your society.', nextSceneId: 'idols', wisdomAdded: 0, feedback: 'Following the blind masses into darkness, no matter how popular, is never the path to truth.' },
+                    { text: 'Use sharp, pristine logic and clear observation to seek out the Ultimate, Unseen Creator.', nextSceneId: 'idols', wisdomAdded: 4, feedback: 'He demonstrated brilliantly that a True God does not set, sleep, disappear, or rely on anything else.' }
+                ]
             },
             {
                 id: 'idols',
-                title: 'The Axe',
-                text: 'While the town was at a festival, he smashed all idols except the big one. "Ask him, if he can speak!" The logic stumped them, but arrogance won.',
-                themeColor: 'red',
+                title: 'The Festival of Silence',
+                text: 'The entire massive kingdom left their city for a grand, roaring annual festival. Feigning illness, Ibrahim remained entirely alone in the enormous, silent temple packed with hundreds of beautifully adorned idols. Food was laid lavishly before them. "Will you not eat?" he mocked the deaf statues. "What is the matter with you that you do not speak?" Swinging a massive axe, he systematically smashed every single idol to absolute pieces, leaving only the very largest one intact, carefully hanging the heavy axe around its stone neck.',
+                themeColor: 'orange',
                 imageHint: '🪓',
-                choices: [{ text: 'The Fire', nextSceneId: 'fire', wisdomAdded: 4 }]
+                choices: [
+                    { text: 'Sneak away quickly under the cover of darkness to desperately avoid brutal execution.', nextSceneId: 'nimrod', wisdomAdded: 0, feedback: 'His incredibly bold goal was to shock them into a sudden, deep realization of their own utter foolishness, not to just commit petty vandalism.' },
+                    { text: 'Calmly stand your ground in the center of the ruins, eagerly waiting to deliver the incredibly powerful punchline.', nextSceneId: 'nimrod', wisdomAdded: 5, feedback: '"Ask the biggest one, if it is able to speak!" he boldly challenged the horrified priests when they returned.' }
+                ]
+            },
+            {
+                id: 'nimrod',
+                title: 'Face to Face with the Tyrant',
+                text: 'The furious townspeople dragged him straight before Nimrod, the ruthless, bloodthirsty tyrant king who actively claimed to be a living god. "My Lord is the one who gives life and causes death," Ibrahim declared fearlessly. Nimrod arrogantly sneered, "I too give life and cause death!" and arbitrarily pardoned a condemned prisoner while executing an innocent man. Unfazed by this idiotic display, Ibrahim aggressively delivered the final, crushing blow: "Allah brings up the sun from the east; so bring it up from the west!" Nimrod was entirely dumbfounded, utterly defeated in logic.',
+                themeColor: 'red',
+                imageHint: '👑',
+                choices: [
+                    { text: 'Tremble and compromise in front of the absolute, terrifying political power of an empire.', nextSceneId: 'fire', wisdomAdded: 0, feedback: 'A true believer fears absolutely no one but Allah.' },
+                    { text: 'Speak the absolute, unvarnished Truth to extreme power without an ounce of hesitation.', nextSceneId: 'fire', wisdomAdded: 4, feedback: 'This immense, towering courage is the defining trait of Khalilullah (The Intimate Friend of Allah).' }
+                ]
             },
             {
                 id: 'fire',
-                title: 'Cool and Safe',
-                text: 'They built a massive fire. HasbunAllah wa Ni\'mal Wakil. He was thrown in. Allah said: "O Fire! Be cool and safe for Ibrahim."',
-                themeColor: 'emerald',
+                title: 'The Great Inferno',
+                text: 'Humiliated, furious, and utterly unable to win the argument, the priests and Nimrod violently resorted to brute force. For an entire month, the kingdom gathered an astronomical amount of wood, lighting a fire so terrifyingly massive that birds flying miles overhead were dropping dead from the sheer, intense heat. They bound Ibrahim tightly with thick ropes and had to use a massive catapult just to launch him into the roaring core of the inferno. As he flew helplessly through the blazing air, the Archangel Jibril appeared mid-air, urgently asking, "Do you have any need?"',
+                themeColor: 'orange',
                 imageHint: '🔥',
-                choices: [{ text: 'The Migration', nextSceneId: 'kings', wisdomAdded: 3 }]
-            },
-            {
-                id: 'kings',
-                title: 'The Tyrant King',
-                text: 'He debated Nimrod. "My Lord gives life and death." Nimrod killed a prisoner and spared one. Ibrahim said: "Allah brings the sun from the East; bring it from the West!" Nimrod was stumped.',
-                themeColor: 'purple',
-                imageHint: '👑',
-                choices: [{ text: 'Leave for Palestine', nextSceneId: 'hajar', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Beg desperately for Jibril\'s immediate supernatural assistance to pull him away from the flames.', nextSceneId: 'hajar', wisdomAdded: 0, feedback: 'While asking angels logic is fine, Ibrahim understood this was the ultimate test of pure Tawakkul.' },
+                    { text: 'Reply with perfect, supreme serenity: "From you, no. HasbunAllah wa ni\'mal-Wakeel (Allah is completely sufficient for me, and He is the best Disposer of affairs)."', nextSceneId: 'hajar', wisdomAdded: 8, feedback: 'Because of this absolutely legendary trust, Allah commanded the universe: "O Fire, be coolness and safety upon Ibrahim!"' }
+                ]
             },
             {
                 id: 'hajar',
-                title: 'The Valley',
-                text: 'Old and grey, he is gifted Ismail from Hajar. He is commanded to leave them in Mecca. Hajar asks: "Did Allah command this?" "Yes." "Then He will not waste us."',
+                title: 'The Desert Test',
+                text: 'Years later, after surviving the fire and migrating to Palestine, Ibrahim (AS) faced a severely agonizing test. Allah commanded him to take his beloved wife Hajar and their infant son Ismail (his firstborn after decades of heartbreaking barrenness) to a completely desolate, scorching, utterly barren valley in Arabia (Makkah). He was commanded to leave them there alone with only a small skin of water and a few meager dates.',
                 themeColor: 'amber',
                 imageHint: '🏜️',
-                choices: [{ text: 'Zamzam', nextSceneId: 'sacrifice', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Argue bitterly with the Divine command, wondering how a baby could possibly survive the brutal desert.', nextSceneId: 'zamzam', wisdomAdded: 0, feedback: 'Faith is not always visually logical. It is raw obedience when everything else screams no.' },
+                    { text: 'Turn away with tears absolutely streaming down your face, trusting fully that Allah will never, ever abandon them.', nextSceneId: 'zamzam', wisdomAdded: 5, feedback: 'Hajar (RA) herself asked, "Did Allah command you to do this?" When he nodded, she boldly replied, "Then He will not neglect us."' }
+                ]
+            },
+            {
+                id: 'zamzam',
+                title: 'The Spring of Zamzam',
+                text: 'As the water completely ran out, the infant Ismail cried terribly from severe dehydration. Hajar (RA) frantically sprinted back and forth exactly seven times between the rocky hills of Safa and Marwa. Suddenly, Jibril miraculously struck the hard desert earth with his heel (or wing), and sweet, pure water fiercely began gushing out! Makkah was miraculously born around this eternal spring, entirely through the desperate running of a profoundly faithful mother.',
+                themeColor: 'blue',
+                imageHint: '💦',
+                choices: [
+                    { text: 'Understand that true miracles often occur right after intensely agonizing human effort and deep desperation.', nextSceneId: 'sacrifice', wisdomAdded: 4 }
+                ]
             },
             {
                 id: 'sacrifice',
-                title: 'The Dream',
-                text: 'The hardest test. Sacrifice your son. Both submit. As the knife touches, Allah calls: "You have fulfilled the vision!" A ram is given instead.',
+                title: 'The Ultimate Dream',
+                text: 'When Ismail was old enough to walk and work beside him, Ibrahim had a recurring, terrifyingly clear vision in his sleep: he saw himself actively sacrificing his beloved son. He deeply knew the dreams of Prophets are direct, undeniable revelation. Heartbroken but resolutely obedient, he told his teenage son. Ismail replied with astonishing courage: "O my father! Do precisely as you are commanded. You will find me, if Allah wills, of the steadfast patient ones."',
                 themeColor: 'rose',
-                imageHint: '🐑',
-                choices: [{ text: 'Build the Kaaba', nextSceneId: 'kaaba', wisdomAdded: 5 }]
+                imageHint: '🗡️',
+                choices: [
+                    { text: 'Try to cleverly interpret the dream metaphorically to aggressively avoid the horrific, unimaginable pain.', nextSceneId: 'kaaba', wisdomAdded: 0, feedback: 'This was the ultimate, horrifying test of absolute love. Who did Ibrahim love more? The gift, or the Giver?' },
+                    { text: 'Lay the knife firmly against his son\'s neck in a breathtaking display of total, absolute surrender.', nextSceneId: 'kaaba', wisdomAdded: 8, feedback: 'As he pressed down, a Heavy Voice called out: "O Ibrahim! You have fulfilled the vision!" A massive ram from Paradise was instantly substituted. The legendary test was over.' }
+                ]
             },
             {
                 id: 'kaaba',
                 title: 'The House of Allah',
-                text: 'Father and son build the Cube. "Accept from us!" They call humanity to Hajj. The echo remains today.',
-                themeColor: 'emerald',
+                text: 'Years later, father and son reunited to construct the very first House established for mankind—the Kaaba at the exact site of Zamzam. Lifting the heavy, rough-hewn stones under the scorching sun, they prayed intensely: "Our Lord, accept this from us! Indeed You are the Hearing, the Knowing." As the simple cubic structure rose, Ibrahim was commanded to call all of mankind to perform Hajj to this sacred, ancient house.',
+                themeColor: 'slate',
                 imageHint: '🕋',
+                choices: [
+                    { text: 'Doubt that anyone will ever hear his voice from the middle of an utterly empty, barren desert.', nextSceneId: 'finish', wisdomAdded: 0, feedback: 'Allah replied: "Your duty is simply to call; Our duty is to strictly convey the message to the ends of the earth."' },
+                    { text: 'Stand atop the mountain and loudly call all of humanity, trusting Allah to carry his voice across time.', nextSceneId: 'finish', wisdomAdded: 5 }
+                ]
+            },
+            {
+                id: 'finish',
+                title: 'The Father of Prophets',
+                text: 'From Ibrahim (AS) sprang the greatest lineage in human history. Through his son Ishaq came Yaqub, Yusuf, Musa, and Isa. Through his son Ismail came the final, ultimate Seal, Muhammad (SAW). For his unparalleled, absolute surrender through fire, exile, and sacrifice, Allah declared him the Khalil (Intimate Friend) and an entire nation unto himself (Ummah). His legacy is the beating heart of Monotheism forever.',
+                themeColor: 'primary',
+                imageHint: '✨',
                 choices: []
             }
         ]

--- a/src/app/home/games/journey/data/prophets_phase3.ts
+++ b/src/app/home/games/journey/data/prophets_phase3.ts
@@ -1,209 +1,268 @@
 import { Journey } from '../journey.model';
 
 export const PROPHETS_PHASE_3: Journey[] = [
+    // LUT (AS)
     {
         id: 'lut',
         prophetName: 'Lut (AS)',
-        title: 'Messenger to Sodom',
-        description: 'Standing firm against a society drowned in vice.',
-        icon: '🏚️',
-        themeColor: 'slate',
+        title: 'The City of Shadows',
+        description: 'Stand as a lone beacon of intense purity amidst a deeply terrifying, utterly depraved society that violently inverted the natural order.',
+        icon: '🌆',
+        themeColor: 'indigo',
         scenes: [
             {
                 id: 'start',
-                title: 'The Nephew',
-                text: 'Lut (AS) migrated with Ibrahim (AS) then was sent to Sodom. Its people robbers, inhospitable, and committed sins no one before them had done.',
+                title: 'The Depraved Towns',
+                text: 'A devoted nephew and fierce follower of Ibrahim (AS), Lut was sent to the wicked, sprawling towns surrounding the Dead Sea, primarily Sodom. This society was not merely corrupt; they had maliciously invented horrifying sins that no human being in the history of the world had ever previously conceived. They openly engaged in rampant banditry, deeply violent assaults, and public, shameless homosexuality, completely abandoning the natural, sacred purity created by Allah.',
                 themeColor: 'slate',
-                imageHint: '🏙️',
-                choices: [{ text: 'Preach Purity', nextSceneId: 'guests', wisdomAdded: 2 }]
-            },
-            {
-                id: 'guests',
-                title: 'The Beautiful Guests',
-                text: 'Angels (Jibril, Mikail, Israfil) came as handsome men. Lut was distressed, knowing his people\'s wickedness. "This is a distressing day."',
-                themeColor: 'rose',
-                imageHint: '🚪',
-                choices: [{ text: 'Protect the Guests', nextSceneId: 'mob', wisdomAdded: 2 }]
+                imageHint: '🌑',
+                choices: [
+                    { text: 'Confront their unprecedented, terrifying depravity with absolute, unyielding firmness.', nextSceneId: 'mob', wisdomAdded: 3 },
+                    { text: 'Try to mildly integrate to slowly reform them from the inside without angering them.', nextSceneId: 'mob', wisdomAdded: 0, feedback: 'When a disease is spreading virulently in public, radical spiritual surgery is required, not silent integration.' }
+                ]
             },
             {
                 id: 'mob',
-                title: 'The Mob',
-                text: 'The townspeople rushed the house. "Did we not forbid you from hosting men?" Lut pleaded: "These are my daughters (women of the town for marriage)... fear Allah!"',
+                title: 'The Beautiful Guests',
+                text: 'Late one evening, three impossibly handsome, glowing young men arrived at Lut\'s door as guests. They were actually the powerful angels Jibril, Mika\'il, and Israfil in human form, sent directly from the fiery destruction of Nimrod to the impending doom of Sodom. However, Lut\'s own deeply treacherous wife secretly signaled the deeply wicked townsfolk. In minutes, a massive, frenzied, violently aggressive mob surrounded his fragile home, loudly demanding the guests be handed over for their vile desires.',
                 themeColor: 'red',
-                imageHint: '😠',
-                choices: [{ text: 'The Angel\'s Reveal', nextSceneId: 'blind', wisdomAdded: 3 }]
+                imageHint: '🚪',
+                choices: [
+                    { text: 'Barricade the heavy wooden door alone and desperately plead with them using logic: "These are my daughters, they are purer for you."', nextSceneId: 'angels', wisdomAdded: 4, feedback: 'He exhausted every absolute diplomatic and desperate plea to protect his sacred guests, showing incredible honor.' },
+                    { text: 'Surrender the mysterious guests to the crazed, violent mob to save your own family.', nextSceneId: 'angels', wisdomAdded: 0, feedback: 'A Prophet\'s sacred honor and fierce protection of a guest in his home is an absolutely unbreakable code.' }
+                ]
             },
             {
-                id: 'blind',
-                title: 'Blinded',
-                text: 'Jibril struck the men with his wing. They lost their sight instantly. "Taste my punishment!" The angels told Lut: "Leave by night. Do not look back."',
-                themeColor: 'slate',
-                imageHint: '👁️',
-                choices: [{ text: 'The Departure', nextSceneId: 'wife', wisdomAdded: 2 }]
+                id: 'angels',
+                title: 'The Blinding Strike',
+                text: 'As the screaming mob violently battered against the breaking door, Lut groaned in pure despair: "If only I had the strength to resist you or a strong fortress to retreat into!" At that exact, terrifying moment, Jibril revealed his true, awe-inspiring angelic form. He simply brushed the mob with the absolute tip of his brilliant wing. Instantly, the blinding strike erased their vision completely, turning their screaming faces into smooth, featureless slates. The angels calmly instructed: "O Lut, we are messengers of your Lord. They will never reach you!"',
+                themeColor: 'cyan',
+                imageHint: '✨',
+                choices: [
+                    { text: 'Command your family to immediately flee into the dark night without ever turning back to look.', nextSceneId: 'punishment', wisdomAdded: 3 }
+                ]
             },
             {
-                id: 'wife',
-                title: 'The Look Back',
-                text: 'As they fled, a mighty scream tore the sky. Lut\'s wife, who supported the people\'s sins, looked back. A stone struck her.',
-                themeColor: 'slate',
-                imageHint: '🗿',
-                choices: [{ text: 'The Overturning', nextSceneId: 'finish', wisdomAdded: 1 }]
+                id: 'punishment',
+                title: 'The Raining Brimstone',
+                text: 'Under the pitch-black cover of night, Lut and his tiny band of believers slipped out of the doomed city. The strict divine command was absolute: do not look back. Tragically, his treacherous wife, whose heart was deeply tangled with the sinners, slowed down and turned her head back to watch. As dawn broke, a terrifying, massive, roaring earthquake struck. Jibril lifted the entire sprawling city of Sodom on his wing high into the screaming sky, flipped it completely upside down, and slammed it into the earth, followed by a relentless pounding rain of baked, hard brimstone stones.',
+                themeColor: 'orange',
+                imageHint: '☄️',
+                choices: [
+                    { text: 'Look intensely forward into the pure dawn light, leaving the horrifying past of the sinners behind forever.', nextSceneId: 'finish', wisdomAdded: 4, feedback: 'Salvation lies strictly in moving forward entirely toward the pleasure and commands of Allah.' }
+                ]
             },
             {
                 id: 'finish',
-                title: 'Marked Stones',
-                text: 'Jibril lifted the cities with his wing tip to the sky, then flipped them upside down. Stones of baked clay rained down.',
-                themeColor: 'indigo',
-                imageHint: '🏜️',
+                title: 'The Lake of Silence',
+                text: 'Where the loud, vicious, deeply arrogant society of Sodom once stood, there arose only a massive, toxically salty, utterly dead body of water—the Dead Sea. The terrifying, completely inverted ruins remain fundamentally buried at the very bottom of the earth\'s lowest elevation. Lut (AS) emerged from the unimaginable horror as a profound symbol of remaining fiercely steadfast and pure when the entire surrounding world plunges into total, violent darkness.',
+                themeColor: 'slate',
+                imageHint: '🌊',
                 choices: []
             }
         ]
     },
+    // ISMAIL (AS)
     {
         id: 'ismail',
         prophetName: 'Ismail (AS)',
-        title: 'The Patient Son',
-        description: 'The ancestor of the Arabs and the grandfather of the Final Prophet.',
-        icon: '💧',
-        themeColor: 'blue',
+        title: 'The Ancestor of the Arabs',
+        description: 'The first deeply devoted son of Ibrahim, miraculously saved from terrifying thirst by Zamzam, and who established a towering legacy of unimaginable patience and total sacrifice.',
+        icon: '🏹',
+        themeColor: 'emerald',
         scenes: [
             {
                 id: 'start',
-                title: 'Left in the Desert',
-                text: 'Ibrahim left Hajar and infant Ismail in Mecca. She asked: "To whom do you leave us?" He said nothing. "To Allah?" "Yes." "He will not lose us."',
-                themeColor: 'amber',
-                imageHint: '🏜️',
-                choices: [{ text: 'The Thirst', nextSceneId: 'zamzam', wisdomAdded: 3 }]
-            },
-            {
-                id: 'zamzam',
-                title: 'Zamzam',
-                text: 'Hajar ran between Safa and Marwa 7 times. The angel struck the ground. Water gushed. She shouted "Zome! Zome!" (Stop/Gather).',
-                themeColor: 'cyan',
-                imageHint: '💧',
-                choices: [{ text: 'The Jurhum Tribe', nextSceneId: 'sacrifice', wisdomAdded: 2 }]
+                title: 'The Desolate Valley',
+                text: 'Left as an utterly helpless, crying infant with his desperately searching mother Hajar (RA) in the completely barren, scorching valley of Makkah, his miraculous survival became legendary. As his mother ran frantically between Safa and Marwa searching for any dying sign of water, the Archangel Jibril himself violently struck the hard desert floor near the baby\'s tiny, kicking feet. A pure, sweet, endlessly flowing spring of cool water (Zamzam) fiercely erupted up through the dry Arabian sand.',
+                themeColor: 'blue',
+                imageHint: '💦',
+                choices: [
+                    { text: 'Marvel at how profound thirst in absolute desolation birthed the single most sacred well in human history.', nextSceneId: 'sacrifice', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'sacrifice',
-                title: 'The Obedience',
-                text: 'Years later, the dream. "O father, do what you are commanded." He lay down. The knife refused to cut. "You have passed the test!"',
+                title: 'The Unimaginable Patience',
+                text: 'When he finally reached his strong teenage years, his elderly father Ibrahim (AS) arrived with a terrifyingly heartbreaking vision: "O my beloved son, indeed I have seen a dream that I must sacrifice you." Instead of crying, resisting in terror, or attempting to desperately flee, Ismail displayed a level of complete, serene Tawakkul (Trust in Allah) that would echo eternally. He looked up calmly and replied: "O my father! Do exactly as you are commanded. You will find me, if Allah wills, of the steadfast patient ones."',
                 themeColor: 'rose',
-                imageHint: '🔪',
-                choices: [{ text: 'Building the House', nextSceneId: 'kaaba', wisdomAdded: 4 }]
+                imageHint: '🤲',
+                choices: [
+                    { text: 'Attempt to brutally fight back or run wildly away from the sharp, terrifying blade.', nextSceneId: 'kaaba', wisdomAdded: 0, feedback: 'He possessed an unbreakable, utterly beautiful submission (Islam) to whatever Allah decreed.' },
+                    { text: 'Bow your head completely in perfect, serene submission, knowing the eternal reward is far greater.', nextSceneId: 'kaaba', wisdomAdded: 5, feedback: 'For this staggering, breathtaking act of sheer obedience, a massive heavenly ram was miraculously substituted by Allah.' }
+                ]
+            },
+            {
+                id: 'kaaba',
+                title: 'Raising the Foundations',
+                text: 'Years later, the devoted father and loving son reunited in Makkah for a monumentally sacred, immense task. Together, sweating under the harsh desert sun, they passionately built the magnificent Kaaba. Ismail would diligently haul the heavy, unhewn stones while Ibrahim meticulously laid the solid foundational courses. As they built the walls higher, they intensely prayed in unison: "Our Lord, aggressively accept this profound effort from us! Indeed, You are the eternally Hearing, the infinitely Knowing."',
+                themeColor: 'slate',
+                imageHint: '🕋',
+                choices: [
+                    { text: 'Understand that true, lasting greatness only comes firmly through incredibly hard work mixed deeply with sincere, focused prayer.', nextSceneId: 'finish', wisdomAdded: 4 }
+                ]
             },
             {
                 id: 'finish',
-                title: 'The Messenger',
-                text: 'He became a messenger to the tribes. He was true to his promise and commanded his family to pray.',
-                themeColor: 'emerald',
+                title: 'The Noble Lineage',
+                text: 'He settled permanently among the fierce Jurhum tribe, expertly learning pure Arabic, brilliantly mastering archery, and becoming a profoundly wise Prophet specifically for the sprawling tribes of Arabia. Through his direct, unbroken bloodline, many centuries later, the shining, absolute final Seal of all Prophets—Muhammad (SAW)—would miraculously emerge from the heart of Makkah.',
+                themeColor: 'gold',
                 imageHint: '✨',
                 choices: []
             }
         ]
     },
+    // ISHAQ (AS)
     {
         id: 'ishaq',
         prophetName: 'Ishaq (AS)',
-        title: 'The Promise',
-        description: 'The son of Sarah, born in old age, father of Yaqub.',
-        icon: '📜',
-        themeColor: 'emerald',
+        title: 'The Miraculous Son',
+        description: 'Born to deeply elderly parents entirely against all natural logic, he became a profound foundational patriarch directly establishing the mighty Children of Israel.',
+        icon: '🌟',
+        themeColor: 'gold',
         scenes: [
             {
                 id: 'start',
-                title: 'The Laugh',
-                text: 'Angels visited Ibrahim. Sarah stood laughing (or amazed). "We give you glad tidings of Ishaq." She struck her face: "An old woman and a barren man?"',
-                themeColor: 'emerald',
-                imageHint: '😲',
-                choices: [{ text: 'The Decree', nextSceneId: 'birth', wisdomAdded: 2 }]
+                title: 'The Unexpected Glad Tidings',
+                text: 'Ibrahim (AS) and his fiercely faithful wife Sarah (RA) had grown incredibly old, reaching their nineties without any children together. One quiet afternoon, majestic angels suddenly appeared in human form at their tent. After intensely delivering the terrifying impending doom regarding Lut\'s city (Sodom), they unexpectedly brought shocking, joyous news. Peeling back the heavy curtain, they announced absolutely clearly: "Sarah, you shall miraculously give birth to a son named Ishaq, and after Ishaq, a deeply blessed grandson named Yaqub!"',
+                themeColor: 'amber',
+                imageHint: '👶',
+                choices: [
+                    { text: 'Laugh in utter, bewildered astonishment: "Shall I truly bear a bouncing child while I am an extremely old woman and my husband is deeply old?"', nextSceneId: 'promise', wisdomAdded: 0, feedback: 'The angels sternly reminded her: "Are you amazed at the sheer decree of Allah? The immense mercy and blessings of Allah are firmly upon you!"' },
+                    { text: 'Immediately prostrate entirely on the floor in overwhelming, intensely tearful gratitude to the Absolute Master of the impossible.', nextSceneId: 'promise', wisdomAdded: 4, feedback: 'Allah is completely capable of seamlessly breaking the "solid rules" of nature whenever He profoundly wills.' }
+                ]
             },
             {
-                id: 'birth',
-                title: 'The Wise Prophet',
-                text: 'Ishaq lived in Palestine. He carried the legacy of Prophethood. Allah praised him as having "hands (strength meant for deeds) and vision (insight)".',
-                themeColor: 'primary',
-                imageHint: '👁️',
-                choices: [{ text: 'The Twins', nextSceneId: 'finish', wisdomAdded: 2 }]
+                id: 'promise',
+                title: 'The Blessed Covenant',
+                text: 'Ishaq grew up completely enveloped in an intensely powerful atmosphere of deep, unwavering faith, passionately learning from his towering, legendary father in Palestine. Unlike his fierce desert-dwelling brother Ismail in Makkah, Ishaq beautifully established his deep Prophethood firmly in the immensely fertile, lush land of Canaan. He powerfully secured the incredibly strong, vital foundation of a mighty, profoundly blessed prophetic line deeply anchored in continuous devotion.',
+                themeColor: 'green',
+                imageHint: '🌿',
+                choices: [
+                    { text: 'Carry forward the absolutely massive, heavy spiritual torch of pure Monotheism to all your descendants.', nextSceneId: 'finish', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'finish',
-                title: 'Israel',
-                text: 'He had two sons, Esau and Yaqub. From Yaqub came the Israelites.',
-                themeColor: 'indigo',
-                imageHint: '🌳',
+                title: 'The Father of Bani Israel',
+                text: 'From the direct, blessed lineage of Ishaq (AS) came Yaqub (also famously named Israel). From Yaqub sprang the immense twelve tribes, and from them descended a staggering, uncountable number of mighty Prophets: including Yusuf, Musa, Dawud, Sulayman, and Isa (AS). His miraculous, logic-defying birth was the profound spark for centuries of intense divine revelation specifically in the Holy Land.',
+                themeColor: 'primary',
+                imageHint: '📜',
                 choices: []
             }
         ]
     },
+    // YUSUF (AS)
     {
         id: 'yusuf',
         prophetName: 'Yusuf (AS)',
-        title: 'The Best Story',
-        description: 'A story of jealousy, patience, temptation, power, and forgiveness.',
-        icon: '👑',
-        themeColor: 'indigo',
+        title: 'The Most Beautiful Story',
+        description: 'Navigate the stunning, intensely emotional epic of fierce betrayal, dark slavery, false accusation, years in a deep dungeon, and an absolute, astonishing rise to ultimate royal power and breathtaking forgiveness.',
+        icon: '🌙',
+        themeColor: 'emerald',
         scenes: [
             {
                 id: 'start',
-                title: 'The Dream',
-                text: '"O father, I saw 11 stars, the sun, and the moon prostrating to me." Yaqub said: "Do not tell your brothers."',
+                title: 'The Heavenly Dream',
+                text: 'As an incredibly handsome, deeply beloved young boy in Canaan, Yusuf rushed specifically to his ancient father Yaqub (AS) with a stunning, vivid dream: "O my father! I saw eleven bright stars, the brilliant sun, and the glowing moon all prostrating deeply to me!" Recognizing clearly the profound, heavy Prophetic destiny ahead, Yaqub held him tightly and fiercely warned: "Do not relate this vivid vision to your jealous brothers, lest they deeply scheme a terrible plot against you."',
                 themeColor: 'indigo',
-                imageHint: '💤',
-                choices: [{ text: 'The Plot', nextSceneId: 'well', wisdomAdded: 1 }]
+                imageHint: '✨',
+                choices: [
+                    { text: 'Naively boast loudly about this amazing dream to all eleven of your deeply resentful older brothers.', nextSceneId: 'well', wisdomAdded: 0, feedback: 'His father urgently sensed the highly dangerous, creeping toxicity of their jealousy fueled directly by Satan.' },
+                    { text: 'Keep the profound secret locked tightly away, entirely trusting your ancient, incredibly wise father\'s warning.', nextSceneId: 'well', wisdomAdded: 3, feedback: 'Protecting blessings from harmful, jealous eyes is a profound, necessary prophetic wisdom.' }
+                ]
             },
             {
                 id: 'well',
-                title: 'The Well',
-                text: 'Brothers threw him in a well. They brought a shirt with fake blood. "A wolf ate him." Yaqub: "Beautiful Patience (Sabrun Jameel)."',
+                title: 'The Betrayal of Brothers',
+                text: 'Driven to complete madness by Satan\'s whispering and intensely fiery, toxic jealousy over their father\'s vast love for him, the older brothers hatched an evil, deeply cowardly plot. Under the clever guise of taking him to aggressively play securely outside, they violently seized the terrified young boy. Ripping off his beloved colorful shirt, they ruthlessly threw him screaming down into the suffocating darkness of a deep, dry well. They brutally smeared his beautiful shirt with fake wolf\'s blood and returned weeping heavily with a completely fabricated, tragic lie.',
                 themeColor: 'slate',
                 imageHint: '🕳️',
-                choices: [{ text: 'Sold in Egypt', nextSceneId: 'sedution', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Scream endlessly in pure, absolute terror while trapped completely alone in the freezing, pitch-black waterless pit.', nextSceneId: 'slavery', wisdomAdded: 0, feedback: 'Allah instantly inspired his terrified heart: "You will certainly inform them of this horrific deed one day while they do not perceive!"' },
+                    { text: 'Hold firmly onto deep, quiet hope in the terrifying dark, absolutely trusting that Allah is always watching from above.', nextSceneId: 'slavery', wisdomAdded: 4, feedback: 'As his father Yaqub responded deeply to the blatant lie: "Beautiful, incredibly beautiful patience (Sabrun Jameel) is what I must seek."' }
+                ]
             },
             {
-                id: 'sedution',
-                title: 'The Test of Chastity',
-                text: 'The Aziz bought him. He grew handsome. The wife tried to seduce him. He ran. She tore his shirt from behind.',
+                id: 'slavery',
+                title: 'Sold for a Few Dirhams',
+                text: 'A wandering, heavily burdened caravan passing nearby dropped an old wooden bucket deep into the well looking for water. Instead of water, they furiously yanked up a stunning, incredibly beautiful young boy. But rather than saving him freely, they callously concealed him maliciously as mere merchandise. In the massive, bustling slave markets of Egypt, he was coldly and cruelly auctioned off for a few paltry, miserable silver coins to the vastly powerful Al-Aziz (Chief Minister) of Egypt.',
+                themeColor: 'amber',
+                imageHint: '🐪',
+                choices: [
+                    { text: 'Fall into utter, deeply crushing despair over intensely losing your profound freedom, royal family, and beautiful homeland.', nextSceneId: 'temptation', wisdomAdded: 0, feedback: 'Prophets never lose complete, pure hope. Allah was perfectly, seamlessly arranging his incredibly steep, astonishing rise.' },
+                    { text: 'Work incredibly hard as a loyal, intensely dignified servant, trusting entirely that Allah firmly controls all destiny.', nextSceneId: 'temptation', wisdomAdded: 3, feedback: 'Because of his pure, spotless excellence (Ihsan), Allah actively gave him a deeply honored, majestic place in the palace.' }
+                ]
+            },
+            {
+                id: 'temptation',
+                title: 'The Locked Doors',
+                text: 'As Yusuf grew rapidly into a strikingly handsome, powerfully built young man, the exceedingly wealthy, intensely lonely wife of Al-Aziz (Zuleikha) became obsessively infatuated with him. One quiet day, she locked every single heavy, solid door in the vast palace tightly. In her incredibly explicit, demanding seduction, she whispered forcefully: "Come to me!" It was the ultimate, terrifyingly intense test of purity: a young, single man, far from home, facing intensely forceful pressure from a highly powerful, elite woman.',
                 themeColor: 'rose',
                 imageHint: '🚪',
-                choices: [{ text: 'Choose Prison', nextSceneId: 'prison', wisdomAdded: 5 }]
+                choices: [
+                    { text: 'Yield slightly to the absolutely massive, terrifying pressure out of strict fear of her immense political power.', nextSceneId: 'prison', wisdomAdded: 0, feedback: 'A heart heavily saturated completely with pure Tawheed firmly rejects all overwhelming temptation, no matter the massive cost.' },
+                    { text: 'Scream intensely: "I seek immense refuge in Allah!" and urgently sprint desperately for the locked, heavy doors.', nextSceneId: 'prison', wisdomAdded: 6, feedback: 'As she violently grabbed forcefully at him, she viciously tore his shirt directly from the back—the absolute, definitive proof of his complete innocence.' }
+                ]
             },
-            // ... (Continuing story in same vein)
             {
                 id: 'prison',
-                title: 'The Prison',
-                text: 'He interpreted dreams for prisoners. "One will pour wine, the other crucified." He asked the survivor to mention him to the King. But he forgot for years.',
+                title: 'The Dark Dungeon',
+                text: 'Despite the torn shirt conclusively proving his complete innocence, the intensely embarrassed aristocratic elite opted for a massive, corrupt cover-up. Yusuf clearly realized that remaining intensely pure outside in this highly toxic society was vastly harder than being imprisoned. He prayed deeply: "My Lord! Deep prison is much dearer to me than that which they aggressively invite me strictly to!" He was unjustly dumped into a rotting, extremely dark, and completely forgotten Egyptian dungeon.',
                 themeColor: 'slate',
                 imageHint: '⛓️',
-                choices: [{ text: 'The King\'s Dream', nextSceneId: 'king', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Become fiercely bitter, overwhelmingly angry, and deeply resentful against God for punishing your sheer innocence.', nextSceneId: 'king', wisdomAdded: 0, feedback: 'He never complained even once. Instead, he constantly called his fellow hopeless inmates to the profound beauty of Tawheed.' },
+                    { text: 'Transform the incredibly dark, miserable dungeon into a brilliant, glowing mosque, eagerly aggressively spreading intense hope and pure faith.', nextSceneId: 'king', wisdomAdded: 5, feedback: 'His flawless character (Ihsan) caused even his fellow hardened, brutal prisoners to intensely love and deeply rely on him.' }
+                ]
             },
             {
                 id: 'king',
-                title: 'Fat and Lean Cows',
-                text: '7 fat cows eaten by 7 lean ones. Yusuf interpreted: 7 years of plenty, 7 of famine. Store the grain.',
-                themeColor: 'amber',
-                imageHint: '🌾',
-                choices: [{ text: 'Rise to Power', nextSceneId: 'brothers', wisdomAdded: 3 }]
+                title: 'Seven Fat Cows',
+                text: 'After several grueling, deeply silent years forgotten in utter darkness, the King of Egypt woke up screaming from a terrifying, incredibly vivid nightmare: Seven extremely scrawny, sickly cows were viciously devouring seven massive, extremely fat cows, and seven totally dry, dead ears of corn were swiftly wrapping around seven brilliantly green ones. All the elite priests and incredibly wise men completely failed to interpret it. The King\'s cupbearer suddenly aggressively remembered the purely flawless, brilliant dream interpreter deeply forgotten in the cold dungeon.',
+                themeColor: 'emerald',
+                imageHint: '🐄',
+                choices: [
+                    { text: 'Refuse stubbornly to interpret it unless they completely clear your falsely ruined name entirely first.', nextSceneId: 'power', wisdomAdded: 0, feedback: 'He possessed absolutely no pettiness. He immediately and aggressively gave the crucial, life-saving advice to save the entire nation.' },
+                    { text: 'Brilliantly and urgently dictate the entire profound vision: Seven incredibly lush years of massive plenty, furiously followed squarely by seven devastating, brutally harsh, absolutely deadly years of intense global famine.', nextSceneId: 'power', wisdomAdded: 4 }
+                ]
+            },
+            {
+                id: 'power',
+                title: 'The Treasures of the Earth',
+                text: 'Profoundly stunned by Yusuf\'s sheer, immense wisdom, absolute deep purity, and incredibly perfect, flawless character, the King ordered him dramatically brought out. His complete innocence was finally established entirely in public. Earning the King\'s absolute, towering trust, Yusuf confidently requested: "Appoint me directly over all the massive storehouses of the land. Indeed, I will be a deeply knowing guardian." He was suddenly elevated instantly from a miserable, locked dungeon slave to the absolute, supreme Treasurer of the entire, highly powerful Egyptian Empire.',
+                themeColor: 'gold',
+                imageHint: '👑',
+                choices: [
+                    { text: 'Immediately and ruthlessly exact intensely brutal revenge against all those arrogant elites who falsely imprisoned you.', nextSceneId: 'brothers', wisdomAdded: 0, feedback: 'A Prophet fiercely wields incredibly massive power solely to aggressively establish true justice and deep mercy, never petty revenge.' },
+                    { text: 'Intensely implement a brilliant, staggeringly massive, perfectly honest agricultural rationing system to fiercely save thousands from certain starvation.', nextSceneId: 'brothers', wisdomAdded: 5 }
+                ]
             },
             {
                 id: 'brothers',
-                title: 'The Reunion',
-                text: 'Brothers came for food. He recognized them. He put a cup in Benjamin\'s bag to keep him. The brothers pleaded.',
-                themeColor: 'emerald',
-                imageHint: '🏆',
-                choices: [{ text: 'The Reveal', nextSceneId: 'forgive', wisdomAdded: 3 }]
+                title: 'The Stunning Reunion',
+                text: 'The severe global famine eventually forcefully pushed his desperate, hungry older brothers from Canaan straight into Egypt aggressively seeking vital grain. They came desperately begging right before him, deeply bowing low. He recognized them perfectly instantly; they had absolutely no idea they were intensely staring directly at the powerful, terrifying royal brother they had viciously thrown into a dark, dry well decades ago.',
+                themeColor: 'primary',
+                imageHint: '🌾',
+                choices: [
+                    { text: 'Immediately reveal who you actually are and viciously torture them endlessly for their cruel, deep betrayal.', nextSceneId: 'forgiveness', wisdomAdded: 0, feedback: 'He masterfully engineered a brilliant, highly complex series of psychological tests to carefully bring them to true, intense repentance first.' },
+                    { text: 'Test their highly corrupted hearts cleverly: deeply plant a royal cup firmly in his beloved full-brother Benjamin\'s heavy saddlebag to forcefully keep him closely nearby.', nextSceneId: 'forgiveness', wisdomAdded: 4, feedback: 'This brilliantly squeezed them to their absolute breaking point, painfully cracking open their hard hearts to intense regret.' }
+                ]
             },
             {
-                id: 'forgive',
+                id: 'forgiveness',
                 title: 'No Blame Today',
-                text: '"I am Yusuf." They were ashamed. "No blame on you today. Allah forgive you." He sent his shirt to heal his father\'s eyes.',
-                themeColor: 'indigo',
-                imageHint: '👕',
-                choices: [{ text: 'The Prostration', nextSceneId: 'finish', wisdomAdded: 2 }]
+                text: 'When the brothers finally, deeply broke down in sheer, desperate tears, Yusuf famously pulled back all the curtains: "Do you know what you did fiercely to Yusuf?" They violently staggered back in absolute, crushing shock, staring into his extremely familiar, beautiful face. Now armed with the absolute, unstoppable, terrifying power to quickly have them all executed on the spot, Yusuf completely lowered his head and delivered history\'s greatest, most breathtaking statement of pure forgiveness.',
+                themeColor: 'rose',
+                imageHint: '❤️',
+                choices: [
+                    { text: 'Declare fiercely and loudly: "No blame will there be entirely upon you this day. May Allah deeply forgive you, and He is the most merciful of the merciful!"', nextSceneId: 'reunion', wisdomAdded: 10, feedback: 'This was an absolutely staggering, monumental mountain-peak of pure human Ihsan and incredibly profound Prophetic mercy.' }
+                ]
             },
             {
-                id: 'finish',
-                title: 'Dream Fulfilled',
-                text: 'Parents and brothers bowed. "This is the interpretation of my dream." Yusuf died a Muslim and joined the righteous.',
+                id: 'reunion',
+                title: 'The Dream Fulfilled',
+                text: 'He urgently instructed them to cast his incredibly fragrant, iconic shirt entirely over his fiercely mourning, entirely blinded father\'s ancient face back in Canaan, miraculously restoring his sight perfectly. Yaqub brought the entire, massive family deeply into highly prosperous Egypt. As the whole family collectively bowed deeply down to him in severe gratitude and honor, Yusuf intensely raised his tearful eyes: "O my beloved father! This is the absolute, perfect fulfillment of that ancient, starry vision!"',
                 themeColor: 'emerald',
                 imageHint: '✨',
                 choices: []

--- a/src/app/home/games/journey/data/prophets_phase4.ts
+++ b/src/app/home/games/journey/data/prophets_phase4.ts
@@ -5,78 +5,100 @@ export const PROPHETS_PHASE_4: Journey[] = [
         id: 'musa',
         prophetName: 'Musa (AS)',
         title: 'Kalimullah',
-        description: 'The one who spoke to Allah. Defeater of Pharaoh.',
+        description: 'The one who spoke to Allah directly. Defeater of Pharaoh.',
         icon: '🌊',
         themeColor: 'cyan',
         scenes: [
             {
                 id: 'start',
                 title: 'Year of Killing',
-                text: 'Pharaoh dreamt a fire from Jerusalem burned Egypt. He ordered baby boys killed. Musa\'s mother was inspired: "Cast him in the river."',
+                text: 'Born in a terrifying era where Pharaoh decreed the ruthless massacre of all Israelite baby boys, Musa\'s mother received a heart-stopping divine inspiration: "Cast him into the river." With profound trust overriding unbearable fear, she placed her fragile newborn in a reed basket upon the rushing Nile.',
                 themeColor: 'red',
                 imageHint: '🧺',
-                choices: [{ text: 'The Palace', nextSceneId: 'palace', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Hide the baby in fear of the soldiers.', nextSceneId: 'palace', wisdomAdded: 0, feedback: 'Her trust in Allah\'s inspiration was so immense she placed her baby in the Nile.' },
+                    { text: 'Trust Allah completely and place him in the basket.', nextSceneId: 'palace', wisdomAdded: 4, feedback: '"We will return him to you and make him of the messengers."' }
+                ]
             },
             {
                 id: 'palace',
                 title: 'Raised by the Enemy',
-                text: 'Asiya (Pharaoh\'s wife) found him. "A joy for me and you." They hired a wet nurse—his own mother. Allah\'s promise is true.',
+                text: 'Guided by providence, the river delivered the basket straight into the palace of the tyrant. Asiya, Pharaoh\'s righteous and compassionate wife, saw the child and pleaded, "He will be a joy to my eye and yours." Miraculously refusing all wet nurses, the royal court unknowingly paid his own heartbroken mother to nurse and raise him safely.',
                 themeColor: 'amber',
                 imageHint: '🏰',
-                choices: [{ text: 'The Accident', nextSceneId: 'flee', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Marvel at Allah\'s perfect, flawless plan.', nextSceneId: 'flee', wisdomAdded: 3, feedback: 'The very enemy seeking to kill him paid his mother to raise him in the royal palace.' }
+                ]
             },
             {
                 id: 'flee',
                 title: 'Escape to Madyan',
-                text: 'He accidentally killed an oppressor. "Lord, I wronged myself." He fled to Madyan, helped two women water flocks, and married one.',
+                text: 'Now a strong man, Musa intervened to protect an oppressed Israelite, accidentally striking the Egyptian guard dead. Struck with deep remorse, he prayed, "My Lord, I have wronged myself!" Hunted by authorities, he fled the bustling cities of Egypt, journeying alone across the harsh desert until he reached the quiet resting wells of Madyan.',
                 themeColor: 'slate',
                 imageHint: '🐑',
-                choices: [{ text: 'The Fire', nextSceneId: 'fire', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Help two women water their flocks selflessly.', nextSceneId: 'fire', wisdomAdded: 4, feedback: 'He drew the heavy cover for them, leading to shelter and marriage.' },
+                    { text: 'Hide and mind his own business.', nextSceneId: 'fire', wisdomAdded: 0, feedback: 'Prophets establish justice, even when they are exhausted refugees.' }
+                ]
             },
             {
                 id: 'fire',
                 title: 'Tuwa Valley',
-                text: 'Seeing a fire, he approached. "O Musa! I am your Lord. Take off your shoes." He was given the Staff and the White Hand.',
+                text: 'A decade later, traveling through the freezing, pitch-black night with his family, Musa spotted a strange, brilliant fire high upon the slopes of Mount Tur. Approaching seeking warmth, the majestic, reality-altering Voice of the Creator called out: "O Musa! Indeed, I am your Lord! Remove your sandals, for you stand in the highly sacred valley of Tuwa!"',
                 themeColor: 'orange',
                 imageHint: '🔥',
-                choices: [{ text: 'Confront Pharaoh', nextSceneId: 'pharaoh', wisdomAdded: 5 }]
+                choices: [
+                    { text: 'Run away from the overwhelming voice.', nextSceneId: 'pharaoh', wisdomAdded: 0, feedback: 'He stood firm, listening directly to the Lord of the Worlds.' },
+                    { text: 'Listen, obey, and accept his Prophethood.', nextSceneId: 'pharaoh', wisdomAdded: 5, feedback: 'He was granted the Staff (snake) and the White Hand.' }
+                ]
             },
             {
                 id: 'pharaoh',
                 title: 'The Magicians',
-                text: 'Reviewing the signs, magicians threw ropes looking like snakes. Musa\'s staff swallowed them. Magicians prostrated. Pharaoh crucified them.',
+                text: 'Standing bravely before the most tyrannical, arrogant king on earth, Musa challenged Pharaoh. A grandiose showdown was staged before the entire nation. Pharaoh\'s elite magicians cast their ropes, creating terrifying, slithering illusions that struck fear into the hearts of the masses.',
                 themeColor: 'purple',
                 imageHint: '🐍',
-                choices: [{ text: 'The Plagues', nextSceneId: 'sea', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Throw his staff with unwavering certainty.', nextSceneId: 'sea', wisdomAdded: 4, feedback: 'His staff swallowed their illusions. Overwhelmed by the Truth, they instantly prostrated.' },
+                    { text: 'Doubt the power of his simple wooden staff.', nextSceneId: 'sea', wisdomAdded: 0, feedback: 'He did feel slight fear, but Allah reassured him: "Fear not, you will overcome."' }
+                ]
             },
             {
                 id: 'sea',
                 title: 'The Red Sea',
-                text: 'Trapped. "My Lord is with me!" He struck the sea. It split like two mountains. Israel crossed; Pharaoh drowned.',
+                text: 'Escaping under the cloak of darkness, the Israelites found themselves utterly trapped between the violently crashing, immense waves of the Red Sea and Pharaoh\'s bloodthirsty, heavily armed battalions closing in fast. Panic erupted.',
                 themeColor: 'blue',
                 imageHint: '🌊',
-                choices: [{ text: 'The Mountain', nextSceneId: 'tur', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Despair: "We will surely be overtaken!"', nextSceneId: 'tur', wisdomAdded: 0, feedback: 'This is what the people said out of sheer terror.' },
+                    { text: 'Proclaim: "No! Indeed, with me is my Lord; He will guide me."', nextSceneId: 'tur', wisdomAdded: 5, feedback: 'He struck the sea. It split like colossal mountains, saving the believers.' }
+                ]
             },
             {
                 id: 'tur',
                 title: 'Request to See',
-                text: '"Lord, show me Yourself." "You cannot see Me." The mountain crumbled. Musa fainted.',
+                text: 'Following the miraculous crossing, Musa was called to the peak of Mount Sinai for forty days of intimate communion to receive the radiant Torah. Overwhelmed by profound spiritual longing and divine proximity, he boldly pleaded: "My Lord, reveal Yourself, that I may look upon You!"',
                 themeColor: 'slate',
                 imageHint: '⛰️',
-                choices: [{ text: 'Samiri', nextSceneId: 'calf', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Accept Allah\'s answer of "You cannot see Me."', nextSceneId: 'calf', wisdomAdded: 3, feedback: 'When Allah revealed a glimpse to the mountain, it shattered into dust, and Musa fainted.' }
+                ]
             },
             {
                 id: 'calf',
                 title: 'The Golden Calf',
-                text: 'While away, Samiri misled them. They worshipped a calf. Musa threw the Tablets in anger. "Why did you not stop them, Harun?"',
+                text: 'Descending the mountain bearing the incredibly heavy, shining Divine Tablets, Musa was met with a devastating sight: his people, impatient and deceived by the hypocrite Samiri, dancing in unholy worship around a lifeless golden calf.',
                 themeColor: 'amber',
                 imageHint: '🐂',
-                choices: [{ text: 'Wanderings', nextSceneId: 'finish', wisdomAdded: 1 }]
+                choices: [
+                    { text: 'Join them out of peer pressure.', nextSceneId: 'finish', wisdomAdded: 0, feedback: 'A Prophet\'s duty is to violently shatter idols. He raged against this severe Shirk.' },
+                    { text: 'Throw down the Tablets in holy rage and confront them.', nextSceneId: 'finish', wisdomAdded: 4, feedback: 'He fiercely reprimanded his brother Harun and the people for falling into Shirk.' }
+                ]
             },
             {
                 id: 'finish',
                 title: 'Death in the Wilderness',
-                text: 'Israel refused to enter Jerusalem ("Go you and your Lord and fight"). They wandered 40 years. Musa died a stone\'s throw from the Holy Land.',
+                text: 'Standing at the very threshold of the Holy Land, his people stubbornly refused to face the battle ahead, declaring, "Go, you and your Lord, and fight!" Condemned to wander the desolate wilderness for forty grueling years, Musa eventually passed away, honored forever as Kalimullah—The One Who Spoke directly to Allah.',
                 themeColor: 'indigo',
                 imageHint: '🏜️',
                 choices: []
@@ -86,47 +108,59 @@ export const PROPHETS_PHASE_4: Journey[] = [
     {
         id: 'sulayman',
         prophetName: 'Sulayman (AS)',
-        title: 'King of Ginns & Men',
-        description: 'The son of Dawud, gifted a kingdom like no other.',
+        title: 'King of Jinns & Men',
+        description: 'The son of Dawud, granted an unparalleled kingdom.',
         icon: '🦅',
         themeColor: 'emerald',
         scenes: [
             {
                 id: 'start',
                 title: 'Inherited Knowledge',
-                text: 'Sulayman succeeded Dawud. "O people! We learned the language of birds." He marched with armies of Jinn, men, and birds.',
+                text: 'Inheriting the glorious throne from his father Dawud, Sulayman prayed for a dominion unlike any other. Allah granted him breathtaking control over the fierce winds, commanded massive, unseen Jinn to dive and build for him, and gifted him the miraculous, intimate understanding of the languages of all birds and creatures.',
                 themeColor: 'emerald',
                 imageHint: '👑',
-                choices: [{ text: 'Valley of Ants', nextSceneId: 'ants', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Use this power for absolute, tyrannical dominion.', nextSceneId: 'ants', wisdomAdded: 0, feedback: 'His prayer was: "Lord, inspire me to be grateful for Your favor."' },
+                    { text: 'Be deeply grateful and march with humble majesty.', nextSceneId: 'ants', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'ants',
-                title: 'The Ant',
-                text: 'An ant cried: "Enter your homes lest Sulayman crush you!" He smiled. "Lord, inspire me to be grateful."',
+                title: 'The Valley of Ants',
+                text: 'Marching his majestic, terrifyingly vast multi-species army of men, giant jinn, and swooping birds, they approached a bustling valley. Sulayman\'s miraculous hearing picked up the tiny, brave voice of a female ant screaming: "O ants! Retreat into your homes, lest Sulayman and his unstoppable army crush you without perceiving!"',
                 themeColor: 'amber',
                 imageHint: '🐜',
-                choices: [{ text: 'Missing Hoopoe', nextSceneId: 'sheba', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Ignore such a tiny creature\'s voice.', nextSceneId: 'sheba', wisdomAdded: 0, feedback: 'He could hear her perfectly due to his miraculous gift.' },
+                    { text: 'Smile, stop the army, and thank Allah.', nextSceneId: 'sheba', wisdomAdded: 4, feedback: 'He smiled in amusement and intense gratitude to his Creator.' }
+                ]
             },
             {
                 id: 'sheba',
                 title: 'Queen of Sheba',
-                text: 'Bilqis ruled Yemen, worshipping the sun. He sent a letter: "In the name of Allah... Come to me in submission."',
+                text: 'His fiercely sharp scout, the Hoopoe bird, urgently returned reporting a magnificently wealthy Queen of Sheba (Bilqis), whose entire nation tragically prostrated to the blinding sun instead of the Creator. Sulayman swiftly sent an authoritative letter: "In the Name of Allah... come to me in completely pure submission."',
                 themeColor: 'purple',
                 imageHint: '🏰',
-                choices: [{ text: 'The Throne', nextSceneId: 'floor', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Demand her gold, subjugating her kingdom.', nextSceneId: 'floor', wisdomAdded: 0, feedback: 'He demanded: "Do not exalt yourselves against me, and come in submission [as Muslims]."' },
+                    { text: 'Send an honorable, firm invitation to Tawheed.', nextSceneId: 'floor', wisdomAdded: 4 }
+                ]
             },
             {
                 id: 'floor',
-                title: 'Glass Floor',
-                text: 'He moved her throne instantly. She entered his palace, tucking her dress thinking the glass floor was water. "I have submitted," she said.',
+                title: 'The Glass Floor',
+                text: 'To profoundly demonstrate absolute Divine Power before her arrival, Sulayman demanded her heavily guarded, jewel-encrusted throne. Delivered literally in the blink of an eye by a scholar with knowledge of the Scripture, he then invited her into his palace. Stepping onto an incredibly polished, crystalline glass floor rushing over water, the highly intelligent Queen realized her power was nothing before Allah.',
                 themeColor: 'cyan',
                 imageHint: '💎',
-                choices: [{ text: 'The End', nextSceneId: 'finish', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Trick her to humiliate her.', nextSceneId: 'finish', wisdomAdded: 0, feedback: 'It was a demonstration of overwhelming technological and spiritual majesty.' },
+                    { text: 'Show her that true glory belongs to Allah alone.', nextSceneId: 'finish', wisdomAdded: 4, feedback: 'She folded her dress, then realized her error: "I have submitted with Sulayman to the Lord of the Worlds."' }
+                ]
             },
             {
                 id: 'finish',
                 title: 'Death on the Staff',
-                text: 'He died leaning on his staff. The Jinn kept working for months until a termite ate the wood and he fell.',
+                text: 'His death was a profound, final lesson shattering the arrogant myth of the Jinn. Sulayman passed away silently while standing, leaning heavily on his strong wooden staff overseeing their exhausting forced labor. The terrified Jinn toiled desperately for a very long time, utterly unaware of his passing until a tiny earthworm ate entirely through his staff. As it snapped and the great king fell, it shattered the illusion that the Jinn knew the Unseen.',
                 themeColor: 'slate',
                 imageHint: '🦯',
                 choices: []
@@ -144,39 +178,50 @@ export const PROPHETS_PHASE_4: Journey[] = [
             {
                 id: 'start',
                 title: 'The Annunciation',
-                text: 'Jibril told Maryam: "I grant you a pure boy." "How? No man touched me." "Allah creates what He wills."',
+                text: 'To deeply test a fiercely legalistic society, Allah commanded a reality-defying miracle. The dazzling Archangel Jibril approached the profoundly pure, heavily devoted virgin Maryam, announcing a holy son. Astonished, she cried, "How? No man has ever touched me!" The decree was absolute: "It is easy for your Lord."',
                 themeColor: 'cyan',
                 imageHint: '👼',
-                choices: [{ text: 'The Birth', nextSceneId: 'cradle', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'She submits to the profound decree of her Lord.', nextSceneId: 'cradle', wisdomAdded: 3 }
+                ]
             },
             {
                 id: 'cradle',
                 title: 'Speech in Cradle',
-                text: 'People accused Maryam. The baby spoke: "I am the slave of Allah. He made me a Prophet and dutiful to my mother."',
+                text: 'Carrying her tiny, newborn infant into the fiercely judgmental town square, Maryam faced a brutal barrage of vicious accusations against her pristine honor. Bound by a strict vow of total silence, she merely pointed to the baby. In an absolutely jaw-dropping miracle, the newborn infant powerfully opened his mouth and spoke with immense, mature prophetic eloquence.',
                 themeColor: 'primary',
                 imageHint: '🗣️',
-                choices: [{ text: 'Miracles', nextSceneId: 'table', wisdomAdded: 3 }]
+                choices: [
+                    { text: 'Claim to be a deity.', nextSceneId: 'table', wisdomAdded: 0, feedback: '"I am the slave of Allah. He made me a Prophet and dutiful to my mother."' },
+                    { text: 'Speak the absolute truth: "I am a slave of Allah."', nextSceneId: 'table', wisdomAdded: 5, feedback: 'This miraculous speech cleared his mother\'s name instantly.' }
+                ]
             },
             {
                 id: 'table',
-                title: 'The Table Spread',
-                text: 'Disciples asked for food from heaven. "Allah, send us a table!" It came down. A feast and a sign.',
+                title: 'The Heavenly Table Spread (Al-Ma\'idah)',
+                text: 'Seeking ultimate, incontrovertible reassurance to bind their hearts absolutely, his closest disciples pleaded for an unprecedented miracle: "O Isa! Can your deeply Powerful Lord send down directly from the heavens a lavish table spread?" This grand feast would be a joyous, majestic festival for the first and the last of them.',
                 themeColor: 'amber',
                 imageHint: '🍱',
-                choices: [{ text: 'The Plot', nextSceneId: 'ascension', wisdomAdded: 2 }]
+                choices: [
+                    { text: 'Pray for it purely as a sign to firmly reassure their hearts.', nextSceneId: 'ascension', wisdomAdded: 4, feedback: 'It descended as a majestic feast, a festival for the first and last of them.' },
+                    { text: 'Deny them, saying it is testing Allah.', nextSceneId: 'ascension', wisdomAdded: 0, feedback: 'Allah answered his prayer, warning of severe punishment for any who disbelieve afterward.' }
+                ]
             },
             {
                 id: 'ascension',
                 title: 'Raised Up',
-                text: 'They planned to kill him. "They killed him not, nor crucified him, but it appeared so." Allah raised him up.',
+                text: 'Furious over his stinging critiques of their massive religious corruption, elite, ruthless authorities plotted a vicious, humiliating public crucifixion. But they planned darkly, and Allah planned perfectly. Flawlessly casting Isa\'s likeness onto a treacherous impostor who was dragged to the cross, Allah miraculously rescued His beloved Messenger, raising him alive securely to the highest heavens.',
                 themeColor: 'indigo',
                 imageHint: '☁️',
-                choices: [{ text: 'The Return', nextSceneId: 'finish', wisdomAdded: 1 }]
+                choices: [
+                    { text: 'Surrender to the unjust mob.', nextSceneId: 'finish', wisdomAdded: 0, feedback: '"They killed him not, nor crucified him, but it appeared so to them."' },
+                    { text: 'Ascend to the heavens by Allah\'s immense power.', nextSceneId: 'finish', wisdomAdded: 4, feedback: 'Allah brilliantly took him up, saving him bodily from his enemies.' }
+                ]
             },
             {
                 id: 'finish',
-                title: 'The Return',
-                text: 'He will return to kill the Dajjal and rule with justice, breaking the cross and killing the pig.',
+                title: 'The Victorious Return',
+                text: 'His incredible, beautifully profound earthly journey is powerfully not over. Muslims passionately hold the deep belief that Isa will physically, visibly descend from the heavens near the terrifying End of Time. He will valiantly slay the tyrannical Dajjal (Antichrist) and restore massive, perfect serene justice across the entire earth.',
                 themeColor: 'emerald',
                 imageHint: '⚔️',
                 choices: []

--- a/src/app/home/games/journey/journey.component.css
+++ b/src/app/home/games/journey/journey.component.css
@@ -57,6 +57,10 @@
 }
 
 /* Animations */
+.animate-fade-in {
+    animation: fadeIn 0.4s ease-out forwards;
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;

--- a/src/app/home/games/journey/journey.component.html
+++ b/src/app/home/games/journey/journey.component.html
@@ -81,6 +81,30 @@
                 <div class="h-1 w-12 bg-current opacity-20 rounded-full"></div>
             </div>
 
+            @if (feedbackMessage()) {
+            <div
+                class="mb-8 p-4 sm:p-5 rounded-xl bg-amber-500/10 dark:bg-amber-500/20 border border-amber-500/30 relative shadow-sm animate-fade-in">
+                <button (click)="dismissFeedback()"
+                    class="absolute top-3 right-3 text-amber-700/50 hover:text-amber-700 dark:text-amber-400/50 dark:hover:text-amber-400 transition-colors">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+                        stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+                <div class="pr-6 flex gap-3 items-start">
+                    <span class="text-xl">💡</span>
+                    <div>
+                        <span
+                            class="text-[10px] sm:text-xs font-bold uppercase tracking-widest text-amber-700 dark:text-amber-400 block mb-1">Divine
+                            Insight</span>
+                        <p class="text-sm sm:text-base font-medium text-amber-900 dark:text-amber-100 leading-snug">
+                            {{feedbackMessage()}}</p>
+                    </div>
+                </div>
+            </div>
+            }
+
             <div class="narrative-text mb-10 sm:mb-12">
                 <p class="text-lg sm:text-xl text-slate-700 dark:text-white/90 leading-relaxed italic">
                     "{{currentScene()?.text}}"
@@ -89,7 +113,7 @@
 
             <!-- Choices -->
             <div class="space-y-3 sm:space-y-4">
-                @for (choice of currentScene()?.choices; track choice.nextSceneId) {
+                @for (choice of currentScene()?.choices; track $index) {
                 <button (click)="makeChoice(choice)"
                     [class]="'w-full p-4 sm:p-5 rounded-2xl font-bold text-sm sm:text-base transition-all duration-300 transform hover:scale-[1.02] shadow-lg flex items-center justify-between group ' + getButtonClass(currentScene()?.themeColor)">
                     <span>{{choice.text}}</span>

--- a/src/app/home/games/journey/journey.component.ts
+++ b/src/app/home/games/journey/journey.component.ts
@@ -27,6 +27,8 @@ export class JourneyComponent {
     isFinished: false
   });
 
+  public readonly feedbackMessage = signal<string | null>(null);
+
   // Computed Values
   public readonly currentJourney = computed(() => {
     const id = this.gameState().currentJourneyId;
@@ -47,6 +49,7 @@ export class JourneyComponent {
 
   // Methods
   public selectJourney(journeyId: string) {
+    this.feedbackMessage.set(null);
     this.gameState.set({
       currentJourneyId: journeyId,
       currentSceneId: 'start',
@@ -59,6 +62,12 @@ export class JourneyComponent {
   public makeChoice(choice: Choice) {
     if (this.gameState().isFinished) return;
 
+    if (choice.feedback) {
+      this.feedbackMessage.set(choice.feedback);
+    } else {
+      this.feedbackMessage.set(null);
+    }
+
     this.gameState.update(s => ({
       ...s,
       currentSceneId: choice.nextSceneId,
@@ -68,7 +77,12 @@ export class JourneyComponent {
     }));
   }
 
+  public dismissFeedback() {
+    this.feedbackMessage.set(null);
+  }
+
   public restart() {
+    this.feedbackMessage.set(null);
     this.gameState.update(s => ({
       ...s,
       currentJourneyId: null,


### PR DESCRIPTION
### Description
This pull request brings massive enhancements to the storytelling content in the `journey` module of the web project. The goal is to deeply engage users by transforming the linear reading experience into an interactive, emotionally resonant adventure.

### Key Changes
1. **Interactive Branching Choices**: Users now face meaningful decisions at critical junctures in each Prophet's life, testing their strategic patience, Tawakkul, and mercy.
2. **"Divine Insight" Feedback**: After each choice, a beautifully animated banner provides wisdom and context, explaining the consequences or divine approval of their actions.
3. **Immersive Prose**: Completely rewrote the narratives for all Prophets:
   - Phase 1: Adam, Idris, Nuh (AS)
   - Phase 2: Hud, Salih, Ibrahim (AS)
   - Phase 3: Lut, Ismail, Ishaq, Yusuf (AS)
   - Phase 4: Musa, Sulayman, Isa (AS)
   - Final Journey: A rich, 20-scene walkthrough of the incredibly epic Seerah of Prophet Muhammad (SAW).
4. **Technical Refinements**: Updated template `track` loops and added native CSS animations for UI perfection.

### Validation
Verified that all choices accurately reflect their Wisdom Points, branching correctly updates the `currentScene`, and all feedback messages animate smoothly via the dev server.