### PR TITLE
feat: Add Hijri Calendar Offset setting with Smart Defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taqwa-tracker",
-      "version": "3.3.7",
+      "version": "3.3.8",
       "dependencies": {
         "@angular/animations": "^21.1.0",
         "@angular/common": "^21.1.0",
@@ -2542,6 +2542,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2559,6 +2562,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2576,6 +2582,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2593,6 +2602,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2610,6 +2622,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2627,6 +2642,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2644,6 +2662,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3180,6 +3201,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3201,6 +3225,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3222,6 +3249,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3243,6 +3273,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3264,6 +3297,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3285,6 +3321,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3462,6 +3501,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3479,6 +3521,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3496,6 +3541,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3513,6 +3561,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3689,6 +3740,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3703,6 +3757,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3717,6 +3774,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3731,6 +3791,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3745,6 +3808,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3759,6 +3825,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3773,6 +3842,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3787,6 +3859,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3801,6 +3876,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3815,6 +3893,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3829,6 +3910,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3843,6 +3927,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3857,6 +3944,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5051,14 +5141,14 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
         "node": ">=20"
@@ -7910,6 +8000,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/log-update/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -10183,17 +10290,17 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taqwa-tracker",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/header/settings/settings.component.html
+++ b/src/app/header/settings/settings.component.html
@@ -148,6 +148,23 @@
         </div>
     </div>
 
+    <!-- Hijri Adjustment -->
+    <div class="group app-settings-item">
+        <div
+            class="text-slate-700 dark:text-gray-400 group-hover:text-slate-900 dark:group-hover:text-gray-200 text-lg font-semibold">
+            Hijri Adjustment
+        </div>
+
+        <select (change)="updateHijriOffset($event)"
+            class="p-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-slate-500 focus:border-slate-500 appearance-none bg-none">
+            <option value="-2" [selected]="prayerService.hijriOffset() === -2">-2 Days</option>
+            <option value="-1" [selected]="prayerService.hijriOffset() === -1">-1 Day</option>
+            <option value="0" [selected]="prayerService.hijriOffset() === 0">0 Days</option>
+            <option value="1" [selected]="prayerService.hijriOffset() === 1">+1 Day</option>
+            <option value="2" [selected]="prayerService.hijriOffset() === 2">+2 Days</option>
+        </select>
+    </div>
+
     <!-- Save Button -->
     @if (authService.isAuthenticated()) {
     <div class="px-5 pb-6 pt-2">

--- a/src/app/header/settings/settings.component.ts
+++ b/src/app/header/settings/settings.component.ts
@@ -96,6 +96,11 @@ export class SettingsComponent implements OnInit {
     this.hadithService.hadithSource.set(select.value);
   }
 
+  updateHijriOffset(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    this.prayerService.setHijriOffset(parseInt(select.value, 10));
+  }
+
   toggleHanafi(): void {
     this.prayerService.toggleHanafi();
   }
@@ -132,7 +137,8 @@ export class SettingsComponent implements OnInit {
       hadith_source: this.selectedSource(),
       hanafi: this.prayerService.isHanafi(),
       salah_alerts: this.notificationService.userNotificationsEnabled(),
-      font_size: this.quranService.ayahFontSize()
+      font_size: this.quranService.ayahFontSize(),
+      hijri_offset: this.prayerService.hijriOffset()
     };
 
     this.authService.savePreferences(preferences).subscribe({

--- a/src/app/home/prayer-times-widget/prayer-times-widget.component.ts
+++ b/src/app/home/prayer-times-widget/prayer-times-widget.component.ts
@@ -60,7 +60,9 @@ export class PrayerTimesWidgetComponent {
   currentDate = signal(new Date());
 
   hijriDate = computed(() => {
-    return moment(this.currentDate()).format('iMMMM iD, iYYYY') + ' AH';
+    const offset = this.salahService.hijriOffset();
+    const adjustedDate = moment(this.currentDate()).add(offset, 'days');
+    return adjustedDate.format('iMMMM iD, iYYYY') + ' AH';
   });
 
   // Computed signal to process prayer times into a view model and determine the current prayer

--- a/src/app/home/tool/calendar/calendar.component.ts
+++ b/src/app/home/tool/calendar/calendar.component.ts
@@ -1,6 +1,7 @@
-import { Component, computed, OnInit, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal, effect } from '@angular/core';
 import { CalendarDay, IslamicEvent } from './calendar.model';
 import moment from 'moment-hijri';
+import { SalahAppService } from '../../../service/salah-app.service';
 
 import { TitleComponent } from '../../../shared/title/title.component';
 
@@ -8,7 +9,7 @@ import { TitleComponent } from '../../../shared/title/title.component';
   selector: 'app-islamic-calendar',
   imports: [
     TitleComponent
-],
+  ],
   templateUrl: './calendar.component.html',
   styleUrl: './calendar.component.css',
   host: {
@@ -16,10 +17,20 @@ import { TitleComponent } from '../../../shared/title/title.component';
   }
 })
 export class IslamicCalendarComponent implements OnInit {
+  private salahService = inject(SalahAppService);
+
   currentDate = signal(moment());
   calendarDays = signal<CalendarDay[]>([]);
   selectedDay = signal<CalendarDay | null>(null);
   showUpcomingEvents = signal(false);
+
+  constructor() {
+    effect(() => {
+      this.salahService.hijriOffset(); // Track this signal
+      // When it changes, re-generate the calendar based on the *current* month
+      this.generateCalendar();
+    });
+  }
 
   hijriMonths = [
     'Muharram', 'Safar', 'Rabi\' al-Awwal', 'Rabi\' al-Thani',
@@ -56,7 +67,8 @@ export class IslamicCalendarComponent implements OnInit {
   });
 
   currentHijriMonth = computed(() => {
-    const date = this.currentDate();
+    const offset = this.salahService.hijriOffset();
+    const date = this.currentDate().clone().add(offset, 'days');
     return `${date.format('iMMMM')} ${date.format('iYYYY')}`;
   });
 
@@ -76,10 +88,12 @@ export class IslamicCalendarComponent implements OnInit {
     }> = [];
 
     // Check events in the next 3 months
+    const offset = this.salahService.hijriOffset();
     for (let i = 0; i <= 90; i++) {
       const checkDate = moment().add(i, 'days');
-      const hijriMonth = parseInt(checkDate.format('iM'));
-      const hijriDay = parseInt(checkDate.format('iD'));
+      const adjustedDate = checkDate.clone().add(offset, 'days');
+      const hijriMonth = parseInt(adjustedDate.format('iM'));
+      const hijriDay = parseInt(adjustedDate.format('iD'));
 
       const event = this.islamicEvents.find(e =>
         e.month === hijriMonth && e.day === hijriDay
@@ -127,10 +141,13 @@ export class IslamicCalendarComponent implements OnInit {
   }
 
   createCalendarDay(date: moment.Moment, currentMonth: number): CalendarDay {
-    const hijriDay = parseInt(date.format('iD'));
-    const hijriMonth = parseInt(date.format('iM'));
-    const hijriMonthName = date.format('iMMMM');
-    const hijriYear = parseInt(date.format('iYYYY'));
+    const offset = this.salahService.hijriOffset();
+    const adjustedHijriDate = date.clone().add(offset, 'days');
+
+    const hijriDay = parseInt(adjustedHijriDate.format('iD'));
+    const hijriMonth = parseInt(adjustedHijriDate.format('iM'));
+    const hijriMonthName = adjustedHijriDate.format('iMMMM');
+    const hijriYear = parseInt(adjustedHijriDate.format('iYYYY'));
     const gregorianDay = date.date();
 
     const isCurrentMonth = date.month() === currentMonth;

--- a/src/app/model/auth.model.ts
+++ b/src/app/model/auth.model.ts
@@ -34,6 +34,7 @@ export interface UserPreferences {
     hanafi?: boolean;
     salah_alerts?: boolean;
     font_size?: number;
+    hijri_offset?: number;
 }
 
 export interface LoginResponse {

--- a/src/app/service/salah-app.service.ts
+++ b/src/app/service/salah-app.service.ts
@@ -18,6 +18,7 @@ export class SalahAppService {
   location$ = this.locationSubject.asObservable();
   error$ = this.errorSubject.asObservable();
   isHanafi = signal<boolean>(false);
+  hijriOffset = signal<number>(0);
 
   constructor(
     private http: HttpClient,
@@ -26,6 +27,7 @@ export class SalahAppService {
     this.getLocation();
     this.setupDailyNotificationScheduling();
     this.loadHanafiPreference();
+    this.loadHijriOffsetPreference();
   }
 
   private loadHanafiPreference() {
@@ -35,10 +37,36 @@ export class SalahAppService {
     }
   }
 
+  private loadHijriOffsetPreference() {
+    const savedPreference = localStorage.getItem('hijriOffset');
+    if (savedPreference !== null) {
+      this.hijriOffset.set(parseInt(savedPreference, 10));
+    } else {
+      // Smart Default: If no preference is saved, check timezone
+      // South Asian countries (India, Pakistan, Bangladesh) are typically +5:00 to +6:00
+      // This is a rough estimation based on timezone offset
+      const tzOffset = new Date().getTimezoneOffset();
+
+      // -330 mins = +5:30 (India)
+      // -300 mins = +5:00 (Pakistan)
+      // -360 mins = +6:00 (Bangladesh)
+      if (tzOffset <= -300 && tzOffset >= -360) {
+        this.hijriOffset.set(-1);
+      } else {
+        this.hijriOffset.set(0);
+      }
+    }
+  }
+
   toggleHanafi() {
     const newValue = !this.isHanafi();
     this.isHanafi.set(newValue);
     localStorage.setItem('hanafiPreference', newValue.toString());
+  }
+
+  setHijriOffset(offset: number) {
+    this.hijriOffset.set(offset);
+    localStorage.setItem('hijriOffset', offset.toString());
   }
 
   private setupDailyNotificationScheduling() {


### PR DESCRIPTION
This pull request resolves the issue where the Islamic calendar gets out of sync with actual regional moon sightings by 1 day.

### Changes:
- **Hijri Offset Preference:** A global setting has been added to user preferences (`hijri_offset`).
- **Smart Default Generation:** New users from South Asian regions (detected via timezone offset) now receive a default offset of `-1` day. Users from other timezones default to `0`.
- **Reactive UI:** The `IslamicCalendarComponent` has been updated to use Angular signals (`effect`) so changes in the offset accurately rebuild the calendar UI without requiring a page reload.
- **Prayer Times Widget Update:** The top-level hijri date display has been updated to account for this offset.
- **Settings Screen:** The offset can now be adjusted between -2 to +2 days in the core settings screen.